### PR TITLE
[BE/feat] 커스텀 예외처리 구현

### DIFF
--- a/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
+++ b/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
@@ -1,0 +1,48 @@
+package com.back.matchduo.global.exeption;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CustomErrorCode {
+
+    // 1. Common (공통)
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+
+    // 2. User (사용자)
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),
+    NOT_FOUND_NICKNAME(HttpStatus.NOT_FOUND, "작성자를 찾을 수 없습니다."),
+    NOT_FOUND_EMAIL(HttpStatus.NOT_FOUND, "이메일이 존재하지 않습니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED, "로그인된 사용자가 없습니다."),
+    USER_STATUS_NOT_BLANK(HttpStatus.BAD_REQUEST, "유저 상태는 공백일 수 없습니다."),
+    DUPLICATE_STATUS(HttpStatus.BAD_REQUEST, "동일한 상태로 변경할 수 없습니다."),
+    INVALID_USER_ROLE(HttpStatus.FORBIDDEN, "권한이 없는 사용자입니다."),
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "정지 상태인 계정입니다."),
+    ACCOUNT_DEACTIVATED(HttpStatus.FORBIDDEN, "비활성화된 계정입니다."),
+    ACCOUNT_BANNED(HttpStatus.FORBIDDEN, "영구 정지된 계정입니다."),
+    SELF_INFORMATION(HttpStatus.UNAUTHORIZED, "본인 정보만 수정할 수 있습니다."),
+    INVALID_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 인증 코드입니다."),
+    EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "인증 코드가 만료되었습니다."),
+    EMAIL_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.BAD_REQUEST, "이메일 인증이 완료되지 않았습니다."),
+
+    // 3. Party (파티)
+    PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 파티를 찾을 수 없습니다."),
+    PARTY_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 종료된 파티입니다."),
+    PARTY_ALREADY_JOINED(HttpStatus.BAD_REQUEST, "이미 참여 중인 파티입니다."),
+    PARTY_IS_FULL(HttpStatus.BAD_REQUEST, "파티 정원이 초과되었습니다."),
+    NOT_PARTY_LEADER(HttpStatus.FORBIDDEN, "파티장만 접근할 수 있는 권한입니다."),
+    PARTY_MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "파티 멤버 정보를 찾을 수 없습니다."),
+    ALREADY_JOINED_PARTY(HttpStatus.BAD_REQUEST, "이미 참여 중인 파티입니다."),
+
+    // 4. Post (모집글) - 추후 구현 시 사용
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 모집글을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/back/matchduo/global/exeption/CustomErrorResponse.java
+++ b/src/main/java/com/back/matchduo/global/exeption/CustomErrorResponse.java
@@ -1,0 +1,22 @@
+package com.back.matchduo.global.exeption;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomErrorResponse {
+
+    private int status;          // HTTP 상태 코드 (예: 400, 404)
+    private String code;         // 커스텀 에러 코드명 (예: "PARTY_FULL")
+    private String message;      // 친절한 메시지 (예: "파티 정원이 꽉 찼습니다.")
+
+    @Builder.Default
+    private String timestamp = LocalDateTime.now().toString(); // 발생 시간
+}

--- a/src/main/java/com/back/matchduo/global/exeption/CustomException.java
+++ b/src/main/java/com/back/matchduo/global/exeption/CustomException.java
@@ -1,0 +1,14 @@
+package com.back.matchduo.global.exeption;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final CustomErrorCode errorCode;
+
+    public CustomException(CustomErrorCode errorCode) {
+        super(errorCode.getMessage()); // RuntimeException에 메시지 전달 (로그용)
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/back/matchduo/global/exeption/GlobalExceptionHandler.java
+++ b/src/main/java/com/back/matchduo/global/exeption/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.back.matchduo.global.exeption;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<CustomErrorResponse> handleCustomException(
+            CustomException e,
+            HttpServletRequest request
+    ) {
+        // 1. 에러 로그 기록 (어떤 에러가, 어떤 URL에서 났는지 확인)
+        log.error("ErrorCode: {}, URL: {}, Message: {}",
+                e.getErrorCode(), request.getRequestURI(), e.getMessage());
+
+        // 2. 응답 DTO 생성
+        CustomErrorResponse response = CustomErrorResponse.builder()
+                .status(e.getErrorCode().getStatus().value()) // 400, 404 등 숫자
+                .code(e.getErrorCode().name())                // "PARTY_FULL" 등 문자열
+                .message(e.getErrorCode().getMessage())       // 메시지
+                .build();
+
+        // 3. ResponseEntity로 감싸서 반환 (중요: HTTP Status Code 설정)
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(response);
+    }
+}


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #12 

## PR / 과제 설명 
- **`CustomErrorCode` Enum 정의**
  - 모든 에러 상황(Common, User, Party 등 도메인별)을 한곳에서 관리하도록 구성
  - HTTP Status Code, 커스텀 에러 코드명, 메시지 포함

- **`CustomException` 클래스 생성**
  - 비즈니스 로직에서 발생하는 예외를 `RuntimeException`을 상속받아 처리
  - 생성 시 `ErrorCode`를 주입받아 구체적인 에러 사유 명시

- **`CustomErrorResponse` DTO 표준화**
  - 에러 발생 시 프론트엔드에 항상 동일한 JSON 포맷(`status`, `code`, `message`, `timestamp`)을 반환하도록 설계

- **`CustomExceptionHandler` (`@RestControllerAdvice`) 구현**
  - 컨트롤러 전역에서 발생하는 `CustomException`을 캐치하여 예외 처리 일원화
  - 에러 발생 시 단순 200 OK가 아닌, **실제 HTTP Status Code(400, 404 등)**를 `ResponseEntity`에 담아 반환하도록 처리
  
  ---
### 사용 방법 

  - **예외 발생 시키기 (Service Logic)**

      - 비즈니스 로직에서 예외 상황 발생 시 `try-catch`나 `IllegalArgumentException` 대신, `ErrorCode`를 사용하여 명시적으로 예외를 발생시킵니다.

    <!-- end list -->

    ```java
    // Service 로직 내부 예시
    if (user == null) {
        // [기존 방식] throw new IllegalArgumentException("유저가 없어요");
        
        // [변경 방식] ErrorCode에 정의된 상황을 throw
        throw new CustomException(ErrorCode.USER_NOT_FOUND);
    }
    ```

  - **ErrorCode 추가하기 (Maintenance)**

      - 새로운 에러 상황이 필요한 경우, `ErrorCode.java` Enum에 상수를 추가하여 관리합니다.

    <!-- end list -->

    ```java
    // global/exception/ErrorCode.java
    public enum ErrorCode {
        // ... 기존 코드 ...
        
        // 작성 예시: 도메인_상황(HttpStatus, "클라이언트에게 보여줄 메시지")
        NEW_ERROR_CASE(HttpStatus.BAD_REQUEST, "새로운 에러 상황입니다.");
    }
    ```