### PR TITLE
[BE/feat] 채팅 API 및 WebSocket 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.gradle.kotlin.dsl.implementation
-
 plugins {
     java
     id("org.springframework.boot") version "3.5.8"
@@ -57,6 +55,11 @@ dependencies {
 
     //mail
     implementation ("org.springframework.boot:spring-boot-starter-mail")
+
+    // STOMP + WebSocket
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
+    implementation("org.springframework.security:spring-security-messaging")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/matchduo/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/back/matchduo/domain/chat/controller/ChatController.java
@@ -1,7 +1,162 @@
 package com.back.matchduo.domain.chat.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.back.matchduo.domain.chat.dto.internal.ChatMessagesWithRoom;
+import com.back.matchduo.domain.chat.dto.internal.ChatRoomDetailWithGameAccount;
+import com.back.matchduo.domain.chat.dto.request.ChatMessageReadRequest;
+import com.back.matchduo.domain.chat.dto.request.ChatMessageSendRequest;
+import com.back.matchduo.domain.chat.dto.request.ChatRoomCreateRequest;
+import com.back.matchduo.domain.chat.dto.response.*;
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatMessageRead;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.chat.service.ChatMessageService;
+import com.back.matchduo.domain.chat.service.ChatRoomService;
+import com.back.matchduo.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
 
 @RestController
+@RequiredArgsConstructor
+@Tag(name = "Chat", description = "채팅 API")
 public class ChatController {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+    @Operation(summary = "채팅방 생성", description = "모집글 기반 1:1 채팅방을 생성합니다. 이미 존재하면 기존 채팅방을 반환합니다 (멱등성 보장).")
+    @PostMapping("/api/v1/chats")
+    public ResponseEntity<ChatRoomCreateResponse> createOrGetRoom(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ChatRoomCreateRequest request) {
+
+        Long userId = userDetails.getId();
+        ChatRoom room = chatRoomService.createOrGet(request.postId(), userId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ChatRoomCreateResponse.of(room, userId));
+    }
+
+    @Operation(summary = "내 채팅방 목록 조회", description = "로그인한 사용자가 참여 중인 채팅방 목록을 조회합니다. 커서 기반 페이징을 지원합니다.")
+    @GetMapping("/api/v1/chats")
+    public ResponseEntity<ChatRoomListResponse> getMyRooms(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") int size) {
+
+        Long userId = userDetails.getId();
+        int pageSize = Math.min(Math.max(size, 1), 100);
+        List<ChatRoomSummaryResponse> summaries = chatRoomService.getMyRoomsWithSummary(userId, cursor, pageSize + 1);
+
+        boolean hasNext = summaries.size() > pageSize;
+        if (hasNext) {
+            summaries = summaries.subList(0, pageSize);
+        }
+        String nextCursor = hasNext && !summaries.isEmpty()
+                ? String.valueOf(summaries.get(summaries.size() - 1).chatRoomId())
+                : null;
+
+        return ResponseEntity.ok(new ChatRoomListResponse(
+                summaries,
+                nextCursor,
+                hasNext
+        ));
+    }
+
+    @Operation(summary = "채팅방 상세 조회", description = "채팅방의 상세 정보를 조회합니다. 상대방 정보, 모집글 요약, 게임 계정 정보를 포함합니다.")
+    @GetMapping("/api/v1/chats/{chatId}")
+    public ResponseEntity<ChatRoomDetailResponse> getRoom(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long chatId) {
+
+        Long userId = userDetails.getId();
+        ChatRoomDetailWithGameAccount result = chatRoomService.getRoomWithGameAccount(chatId, userId);
+        return ResponseEntity.ok(ChatRoomDetailResponse.of(result.room(), userId, result.otherGameAccount()));
+    }
+
+    @Operation(summary = "채팅방 나가기", description = "채팅방에서 퇴장합니다. 한 명이라도 나가면 해당 채팅방은 닫히며 메시지 전송이 불가합니다.")
+    @DeleteMapping("/api/v1/chats/{chatId}")
+    public ResponseEntity<ChatRoomLeaveResponse> leaveRoom(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long chatId) {
+
+        Long userId = userDetails.getId();
+        ChatRoom room = chatRoomService.leave(chatId, userId);
+        return ResponseEntity.ok(ChatRoomLeaveResponse.of(room));
+    }
+
+    @Operation(summary = "메시지 전송", description = "채팅방에 메시지를 전송합니다. TEXT, SYSTEM 타입을 지원합니다.")
+    @PostMapping("/api/v1/chats/{chatId}/messages")
+    public ResponseEntity<ChatMessageSendResponse> sendMessage(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long chatId,
+            @Valid @RequestBody ChatMessageSendRequest request) {
+
+        Long userId = userDetails.getId();
+        ChatMessage message = chatMessageService.send(
+                chatId, userId, request.messageType(), request.content());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ChatMessageSendResponse.of(message));
+    }
+
+    @Operation(summary = "메시지 목록 조회", description = "채팅방의 메시지 목록을 조회합니다. 최신순 정렬, 커서 기반 페이징을 지원합니다.")
+    @GetMapping("/api/v1/chats/{chatId}/messages")
+    public ResponseEntity<ChatMessageListResponse> getMessages(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long chatId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "30") int size) {
+
+        Long userId = userDetails.getId();
+        int pageSize = Math.min(Math.max(size, 1), 100);
+
+        ChatMessagesWithRoom result =
+                chatMessageService.getMessagesWithRoom(chatId, userId, cursor, pageSize + 1);
+
+        List<ChatMessage> messages = result.messages();
+        boolean hasNext = messages.size() > pageSize;
+
+        List<ChatMessage> finalMessages = hasNext
+                ? new ArrayList<>(messages.subList(0, pageSize))
+                : new ArrayList<>(messages);
+
+        Long nextCursor = hasNext && !finalMessages.isEmpty()
+                ? finalMessages.get(finalMessages.size() - 1).getId()
+                : null;
+
+        return ResponseEntity.ok(ChatMessageListResponse.of(
+                result.room(),
+                userId,
+                finalMessages,
+                nextCursor,
+                hasNext
+        ));
+    }
+
+    @Operation(summary = "메시지 읽음 처리", description = "지정한 메시지까지 읽음 처리합니다. 안 읽은 메시지 수 계산에 사용됩니다.")
+    @PostMapping("/api/v1/chats/{chatId}/messages/read")
+    public ResponseEntity<ChatMessageReadResponse> markAsRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long chatId,
+            @Valid @RequestBody ChatMessageReadRequest request) {
+
+        Long userId = userDetails.getId();
+        ChatMessageRead readState = chatMessageService.markReadUpTo(
+                chatId, userId, request.lastReadMessageId());
+
+        return ResponseEntity.ok(ChatMessageReadResponse.of(
+                chatId,
+                readState.getLastReadMessage() != null ? readState.getLastReadMessage().getId() : null,
+                readState.getLastReadAt()
+        ));
+    }
 }

--- a/src/main/java/com/back/matchduo/domain/chat/dto/internal/ChatMessagesWithRoom.java
+++ b/src/main/java/com/back/matchduo/domain/chat/dto/internal/ChatMessagesWithRoom.java
@@ -1,0 +1,16 @@
+package com.back.matchduo.domain.chat.dto.internal;
+
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+
+import java.util.List;
+
+/**
+ * 메시지 목록과 채팅방 정보를 함께 담는 내부 DTO
+ * - Service 레이어에서 중복 조회를 방지하기 위해 사용
+ * - API 요청/응답이 아닌 Service 내부 전달용
+ */
+public record ChatMessagesWithRoom(
+        List<ChatMessage> messages,
+        ChatRoom room
+) {}

--- a/src/main/java/com/back/matchduo/domain/chat/dto/internal/ChatRoomDetailWithGameAccount.java
+++ b/src/main/java/com/back/matchduo/domain/chat/dto/internal/ChatRoomDetailWithGameAccount.java
@@ -1,0 +1,14 @@
+package com.back.matchduo.domain.chat.dto.internal;
+
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+
+/**
+ * 채팅방 상세 정보와 상대방 게임 계정을 함께 담는 내부 DTO
+ * - Service 레이어에서 중복 조회를 방지하기 위해 사용
+ * - API 요청/응답이 아닌 Service 내부 전달용
+ */
+public record ChatRoomDetailWithGameAccount(
+        ChatRoom room,
+        GameAccount otherGameAccount
+) {}

--- a/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatMessageListResponse.java
+++ b/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatMessageListResponse.java
@@ -1,17 +1,18 @@
 package com.back.matchduo.domain.chat.dto.response;
 
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.user.entity.User;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 /**
  * 채팅 메시지 목록 응답 (커서 페이징)
- * - header: 채팅방 헤더 정보 (상대 정보, 모집글 요약)
- * - messages: 메시지 목록
  */
 public record ChatMessageListResponse(
         Long chatRoomId,
         ChatHeaderResponse header, // 헤더 영역(상대 정보/모집글 요약/모집 상태)
-        Long myLastReadMessageId,  // 내 기준 마지막 읽은 메시지 ID
         List<ChatMessageItemResponse> messages, // 채팅 메시지 목록
         Long nextCursor,
         boolean hasNext
@@ -28,15 +29,22 @@ public record ChatMessageListResponse(
     /** 채팅 상대(1:1) 사용자 정보*/
     public record OtherUserResponse(
             Long userId,
-            String communityNickname,
-            String profileImage,
-            String gameNicknameTag
-    ) {}
+            String nickname,
+            String profileImage
+    ) {
+        public static OtherUserResponse of(User user) {
+            return new OtherUserResponse(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getProfileImage()
+            );
+        }
+    }
 
     /** 모집글 요약 */
     public record PostSummaryResponse(
             Long postId,
-            String gameMode,
+            String queueType,
             String memo
     ) {}
 
@@ -47,5 +55,49 @@ public record ChatMessageListResponse(
             String content,
             String messageType,
             LocalDateTime createdAt
-    ) {}
+    ) {
+        public static ChatMessageItemResponse of(ChatMessage message) {
+            return new ChatMessageItemResponse(
+                    message.getId(),
+                    message.getSender().getId(),
+                    message.getContent(),
+                    message.getMessageType().name(),
+                    message.getCreatedAt()
+            );
+        }
+    }
+
+    /** 팩토리 메서드 */
+    public static ChatMessageListResponse of(
+            ChatRoom room,
+            Long userId,
+            List<ChatMessage> messages,
+            Long nextCursor,
+            boolean hasNext
+    ) {
+        boolean isSender = room.isSender(userId);
+        User otherUser = isSender ? room.getReceiver() : room.getSender();
+
+        ChatHeaderResponse header = new ChatHeaderResponse(
+                OtherUserResponse.of(otherUser),
+                new PostSummaryResponse(
+                        room.getPost().getId(),
+                        room.getPost().getQueueType().name(),
+                        room.getPost().getMemo()
+                ),
+                room.getPost().getStatus().name()
+        );
+
+        List<ChatMessageItemResponse> messageItems = messages.stream()
+                .map(ChatMessageItemResponse::of)
+                .toList();
+
+        return new ChatMessageListResponse(
+                room.getId(),
+                header,
+                messageItems,
+                nextCursor,
+                hasNext
+        );
+    }
 }

--- a/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatRoomDetailResponse.java
+++ b/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatRoomDetailResponse.java
@@ -1,19 +1,62 @@
 package com.back.matchduo.domain.chat.dto.response;
 
 import com.back.matchduo.domain.chat.entity.ChatMemberRole;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 
-/**
- * 채팅방 상세 정보 응답
- * - 메시지 목록은 별도 API에서 조회
- */
+/** 채팅방 상세 정보 응답 */
 public record ChatRoomDetailResponse(
         Long chatRoomId,
         Long postId,
-        boolean isActive,
+        boolean isOpen,
         LocalDateTime createdAt,
         ChatMemberRole myRole,
         boolean otherLeft,
-        boolean myLeft
-) {}
+        boolean myLeft,
+        OtherUserDetailResponse otherUser,
+        String queueType,
+        String memo,
+        String postStatus
+) {
+
+    public record OtherUserDetailResponse(
+            Long userId,
+            String nickname,
+            String profileImage,
+            String gameNickname,
+            String gameTag
+    ) {
+        public static OtherUserDetailResponse of(User user, GameAccount gameAccount) {
+            return new OtherUserDetailResponse(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getProfileImage(),
+                    gameAccount != null ? gameAccount.getGameNickname() : null,
+                    gameAccount != null ? gameAccount.getGameTag() : null
+            );
+        }
+    }
+
+    public static ChatRoomDetailResponse of(ChatRoom room, Long userId, GameAccount otherGameAccount) {
+        ChatMemberRole myRole = room.getMemberRole(userId);
+        boolean isSender = myRole == ChatMemberRole.SENDER;
+        User otherUser = isSender ? room.getReceiver() : room.getSender();
+
+        return new ChatRoomDetailResponse(
+                room.getId(),
+                room.getPost().getId(),
+                room.isOpen(),
+                room.getCreatedAt(),
+                myRole,
+                isSender ? room.isReceiverLeft() : room.isSenderLeft(),
+                isSender ? room.isSenderLeft() : room.isReceiverLeft(),
+                OtherUserDetailResponse.of(otherUser, otherGameAccount),
+                room.getPost().getQueueType().name(),
+                room.getPost().getMemo(),
+                room.getPost().getStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatRoomLeaveResponse.java
+++ b/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatRoomLeaveResponse.java
@@ -2,25 +2,21 @@ package com.back.matchduo.domain.chat.dto.response;
 
 import com.back.matchduo.domain.chat.entity.ChatRoom;
 
-import java.time.LocalDateTime;
-
 /**
  * 채팅방 나가기
- * - isClosed: 채팅 가능 여부 (한 쪽이라도 나갔으면 true)
- * - isActive: soft delete 여부 (둘 다 나가면 false)
+ * - isClosed: 채팅 불가 여부 (한 쪽이라도 나갔으면 true)
+ * - isFullyClosed: 양쪽 모두 나갔는지 여부
  */
 public record ChatRoomLeaveResponse(
         Long chatRoomId,
         boolean isClosed,
-        boolean isActive,
-        LocalDateTime disabledAt
+        boolean isFullyClosed
 ) {
     public static ChatRoomLeaveResponse of(ChatRoom chatRoom) {
         return new ChatRoomLeaveResponse(
-              chatRoom.getId(),
-              chatRoom.isClosed(),
-              Boolean.TRUE.equals(chatRoom.getIsActive()),
-              chatRoom.getDeletedAt()
+                chatRoom.getId(),
+                chatRoom.isClosed(),
+                chatRoom.isFullyClosed()
         );
     }
 }

--- a/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatRoomSummaryResponse.java
+++ b/src/main/java/com/back/matchduo/domain/chat/dto/response/ChatRoomSummaryResponse.java
@@ -1,6 +1,9 @@
 package com.back.matchduo.domain.chat.dto.response;
 
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
 import com.back.matchduo.domain.chat.entity.MessageType;
+import com.back.matchduo.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 
@@ -9,7 +12,6 @@ import java.time.LocalDateTime;
  * - 채팅방 목록 1건에 필요한 데이터
  * - unreadCount: 안 읽은 메시지 수
  * - lastActivityAt: 목록 정렬/커서 페이징 기준
- *
  */
 public record ChatRoomSummaryResponse(
         Long chatRoomId,
@@ -17,7 +19,7 @@ public record ChatRoomSummaryResponse(
         OtherUserResponse otherUser,
         LastMessageResponse lastMessage,
         int unreadCount,
-        String gameMode,
+        String queueType,
         String memo,
         boolean isActive,
         LocalDateTime lastActivityAt
@@ -27,7 +29,15 @@ public record ChatRoomSummaryResponse(
             Long userId,
             String nickname,
             String profileImage
-    ) {}
+    ) {
+        public static OtherUserResponse of(User user) {
+            return new OtherUserResponse(
+                    user.getId(),
+                    user.getNickname(),
+                    user.getProfileImage()
+            );
+        }
+    }
 
     public record LastMessageResponse(
             Long chatMessageId,
@@ -35,11 +45,43 @@ public record ChatRoomSummaryResponse(
             String content,
             MessageType messageType,
             LocalDateTime createdAt
-    ) {}
+    ) {
+        public static LastMessageResponse of(ChatMessage message) {
+            if (message == null) return null;
+            return new LastMessageResponse(
+                    message.getId(),
+                    message.getSender().getId(),
+                    message.getContent(),
+                    message.getMessageType(),
+                    message.getCreatedAt()
+            );
+        }
+    }
+
+    public static ChatRoomSummaryResponse of(
+            ChatRoom room,
+            Long userId,
+            ChatMessage lastMessage,
+            int unreadCount
+    ) {
+        boolean isSender = room.isSender(userId);
+        User otherUser = isSender ? room.getReceiver() : room.getSender();
+
+        return new ChatRoomSummaryResponse(
+                room.getId(),
+                room.getPost().getId(),
+                OtherUserResponse.of(otherUser),
+                LastMessageResponse.of(lastMessage),
+                unreadCount,
+                room.getPost().getQueueType().name(),
+                room.getPost().getMemo(),
+                room.isActive(),
+                lastMessage != null ? lastMessage.getCreatedAt() : room.getCreatedAt()
+        );
+    }
 
     public boolean hasUnread() {
         return unreadCount > 0;
     }
-
 }
 

--- a/src/main/java/com/back/matchduo/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/com/back/matchduo/domain/chat/entity/ChatMessage.java
@@ -60,8 +60,8 @@ public class ChatMessage {
 
     @PrePersist
     private void prePersist() {
-        if (sessionNo == null && chatRoom != null) {
-            sessionNo = chatRoom.getCurrentSessionNo();
+        if (sessionNo == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_SESSION);
         }
     }
 

--- a/src/main/java/com/back/matchduo/domain/chat/repository/ChatMessageReadRepository.java
+++ b/src/main/java/com/back/matchduo/domain/chat/repository/ChatMessageReadRepository.java
@@ -1,11 +1,32 @@
 package com.back.matchduo.domain.chat.repository;
 
 import com.back.matchduo.domain.chat.entity.ChatMessageRead;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface ChatMessageReadRepository extends JpaRepository<ChatMessageRead, Long> {
-    // 방-유저 조합으로 읽음 상태 조회
+    /** 방-유저 조합으로 읽음 상태 조회 */
     Optional<ChatMessageRead> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
+
+    /** 새 세션 시작 시 읽음 상태 벌크 초기화 */
+    @Modifying
+    @Query("UPDATE ChatMessageRead r " +
+           "SET r.lastReadMessage = NULL, r.lastReadAt = NULL " +
+           "WHERE r.chatRoom.id = :chatRoomId")
+    void resetAllForRoom(@Param("chatRoomId") Long chatRoomId);
+
+    /** 읽음 상태 업데이트 시 비관적 락 조회 */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM ChatMessageRead r " +
+           "WHERE r.chatRoom.id = :chatRoomId " +
+           "AND r.user.id = :userId")
+    Optional<ChatMessageRead> findByChatRoomIdAndUserIdWithLock(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("userId") Long userId);
 }

--- a/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
@@ -1,20 +1,53 @@
 package com.back.matchduo.domain.chat.repository;
 
 import com.back.matchduo.domain.chat.entity.ChatRoom;
-import org.springframework.data.domain.Page;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    // 모집글 + 신청자 조합으로 채팅방 조회 (멱등 처리용)
+    /** 모집글 + 신청자 조합으로 채팅방 조회 (멱등 처리용) */
     Optional<ChatRoom> findByPostIdAndSenderId(Long postId, Long senderId);
 
-    // 내 채팅방 목록 (receiver 또는 sender로 참여)
-    List<ChatRoom> findByReceiverIdOrSenderId(Long receiverId, Long senderId);
+    /** 내 채팅방 목록 조회 (커서 기반 페이징, N+1 방지용 JOIN FETCH) */
+    @Query("SELECT r FROM ChatRoom r " +
+           "JOIN FETCH r.post p " +
+           "JOIN FETCH p.gameMode " +
+           "JOIN FETCH r.receiver JOIN FETCH r.sender " +
+           "WHERE (r.receiver.id = :userId OR r.sender.id = :userId) " +
+           "AND p.isActive = true " +
+           "AND NOT (r.senderLeft = true AND r.receiverLeft = true) " +
+           "AND (:cursor IS NULL OR r.id < :cursor) " +
+           "ORDER BY r.id DESC")
+    List<ChatRoom> findMyRooms(@Param("userId") Long userId,
+                               @Param("cursor") Long cursor,
+                               Pageable pageable);
 
-    // 커서 페이징용 (최신순)
-    Page<ChatRoom> findByReceiverIdOrSenderIdOrderByUpdatedAtDesc(Long receiverId, Long senderId, Pageable pageable);
+    /** 채팅방 나가기 시 비관적 락 조회 */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM ChatRoom r WHERE r.id = :id")
+    Optional<ChatRoom> findByIdWithLock(@Param("id") Long id);
+
+    /** 닫힌 방 재활성화 시에만 락 사용 */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM ChatRoom r " +
+           "WHERE r.post.id = :postId " +
+           "AND r.sender.id = :senderId")
+    Optional<ChatRoom> findByPostIdAndSenderIdWithLock(
+            @Param("postId") Long postId,
+            @Param("senderId") Long senderId);
+
+    /** WebSocket 구독 시 채팅방 멤버 검증용 */
+    @Query("SELECT COUNT(r) > 0 FROM ChatRoom r " +
+           "WHERE r.id = :chatId " +
+           "AND (r.sender.id = :userId OR r.receiver.id = :userId)")
+    boolean existsByIdAndMember(
+            @Param("chatId") Long chatId,
+            @Param("userId") Long userId);
 }

--- a/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
@@ -50,4 +50,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     boolean existsByIdAndMember(
             @Param("chatId") Long chatId,
             @Param("userId") Long userId);
+
+    /** 채팅방 상세 조회 (sender, receiver, post 함께 로드 - N+1 방지) */
+    @Query("SELECT r FROM ChatRoom r " +
+           "JOIN FETCH r.sender " +
+           "JOIN FETCH r.receiver " +
+           "JOIN FETCH r.post p " +
+           "WHERE r.id = :id")
+    Optional<ChatRoom> findByIdWithDetails(@Param("id") Long id);
 }

--- a/src/main/java/com/back/matchduo/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/back/matchduo/domain/chat/service/ChatMessageService.java
@@ -61,7 +61,7 @@ public class ChatMessageService {
      * - room 조회/검증 + pageable 생성 + sessionNo 검증 + 메시지 조회를 한 곳에서 처리
      */
     private ChatMessagesWithRoom loadMessagesWithRoom(Long chatRoomId, Long requesterId, Long cursorMessageId, int size) {
-        ChatRoom room = getRoomOrThrow(chatRoomId);
+        ChatRoom room = getRoomWithDetailsOrThrow(chatRoomId);
         validateMember(room, requesterId);
 
         int pageSize = (size <= 0 || size > 100) ? 30 : size;
@@ -127,6 +127,15 @@ public class ChatMessageService {
             throw new CustomException(CustomErrorCode.CHAT_INVALID_CHAT_ROOM);
         }
         return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    /** 채팅방 상세 조회 (sender, receiver, post 함께 로드) */
+    private ChatRoom getRoomWithDetailsOrThrow(Long chatRoomId) {
+        if (chatRoomId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_CHAT_ROOM);
+        }
+        return chatRoomRepository.findByIdWithDetails(chatRoomId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
     }
 

--- a/src/main/java/com/back/matchduo/domain/chat/service/ChatMessageService.java
+++ b/src/main/java/com/back/matchduo/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,160 @@
+package com.back.matchduo.domain.chat.service;
+
+import com.back.matchduo.domain.chat.dto.internal.ChatMessagesWithRoom;
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatMessageRead;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.chat.entity.MessageType;
+import com.back.matchduo.domain.chat.repository.ChatMessageReadRepository;
+import com.back.matchduo.domain.chat.repository.ChatMessageRepository;
+import com.back.matchduo.domain.chat.repository.ChatRoomRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatMessageService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageReadRepository chatMessageReadRepository;
+    private final UserRepository userRepository;
+
+    /** 메시지 전송 */
+    public ChatMessage send(Long chatRoomId, Long senderId, MessageType type, String content) {
+        ChatRoom room = getRoomOrThrow(chatRoomId);
+
+        validateSenderId(senderId);
+        User sender = userRepository.getReferenceById(senderId);
+
+        validateMember(room, senderId);
+        validateRoomOpen(room);
+
+        ChatMessage message = ChatMessage.create(room, sender, type, content);
+        return chatMessageRepository.save(message);
+    }
+
+    /**
+     * 메시지 목록과 채팅방 정보를 함께 조회 (중복 조회 방지)
+     * - cursorMessageId가 null이면 최신부터
+     * - 현재 세션(room.currentSessionNo)의 메시지만 조회
+     * - 결과는 최신 -> 과거(desc) 정렬로 반환
+     * */
+    @Transactional(readOnly = true)
+    public ChatMessagesWithRoom getMessagesWithRoom(Long chatRoomId, Long requesterId, Long cursorMessageId, int size) {
+        return loadMessagesWithRoom(chatRoomId, requesterId, cursorMessageId, size);
+    }
+
+    /**
+     * 공통 조회 로직 (중복 제거)
+     * - room 조회/검증 + pageable 생성 + sessionNo 검증 + 메시지 조회를 한 곳에서 처리
+     */
+    private ChatMessagesWithRoom loadMessagesWithRoom(Long chatRoomId, Long requesterId, Long cursorMessageId, int size) {
+        ChatRoom room = getRoomOrThrow(chatRoomId);
+        validateMember(room, requesterId);
+
+        int pageSize = (size <= 0 || size > 100) ? 30 : size;
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        Integer sessionNo = room.getCurrentSessionNo();
+        if (sessionNo == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_SESSION);
+        }
+
+        List<ChatMessage> messages = chatMessageRepository.findByCursorWithSender(
+                chatRoomId, sessionNo, cursorMessageId, pageable);
+
+        return new ChatMessagesWithRoom(messages, room);
+    }
+
+    /**
+     * 읽음 처리 (마지막 읽은 메시지 포인터)
+     * - 현재 세션 메시지만 반영 (이전 세션 메시지는 무시)
+     */
+    public ChatMessageRead markReadUpTo(Long chatRoomId, Long requesterId, Long chatMessageId) {
+        if (requesterId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_USER_ID);
+        }
+        if (chatMessageId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_MESSAGE);
+        }
+
+        ChatRoom room = getRoomOrThrow(chatRoomId);
+        validateMember(room, requesterId);
+
+        ChatMessage message = getMessageOrThrow(chatMessageId);
+
+        // 메시지-채팅방 불일치 시 차단
+        if (message.getChatRoom() == null || message.getChatRoom().getId() == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_CHAT_ROOM);
+        }
+        if (!room.getId().equals(message.getChatRoom().getId())) {
+            throw new CustomException(CustomErrorCode.CHAT_ROOM_MISMATCH);
+        }
+
+        // (room, user) 1행, 없으면 생성
+        ChatMessageRead readState = chatMessageReadRepository
+                .findByChatRoomIdAndUserIdWithLock(room.getId(), requesterId)
+                        .orElseGet(() -> {
+                            try {
+                                User user = userRepository.getReferenceById(requesterId);
+                                return chatMessageReadRepository.save(ChatMessageRead.create(room, user));
+                            } catch (DataIntegrityViolationException e) {
+                                return chatMessageReadRepository.findByChatRoomIdAndUserId(room.getId(), requesterId)
+                                        .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_READ_STATE_INVALID));
+
+                            }
+                        });
+
+        readState.markReadUpTo(message);
+        return chatMessageReadRepository.save(readState);
+    }
+
+    /** 헬퍼 메서드 */
+    private ChatRoom getRoomOrThrow(Long chatRoomId) {
+        if (chatRoomId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_CHAT_ROOM);
+        }
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private ChatMessage getMessageOrThrow(Long chatMessageId) {
+        if (chatMessageId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_MESSAGE);
+        }
+        return chatMessageRepository.findById(chatMessageId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_MESSAGE_NOT_FOUND));
+    }
+
+    private void validateSenderId(Long senderId) {
+        if (senderId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_SENDER);
+        }
+    }
+
+    private void validateMember(ChatRoom room, Long userId) {
+        if (userId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_USER_ID);
+        }
+        room.getMemberRole(userId); // 방 구성원 검증
+    }
+
+    private void validateRoomOpen(ChatRoom room) {
+        if (room.isClosed()) { // 한쪽이라도 나가면 채팅방 닫힘
+            throw new CustomException(CustomErrorCode.CHAT_ROOM_CLOSED);
+        }
+    }
+
+}

--- a/src/main/java/com/back/matchduo/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/back/matchduo/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,236 @@
+package com.back.matchduo.domain.chat.service;
+
+import com.back.matchduo.domain.chat.dto.internal.ChatRoomDetailWithGameAccount;
+import com.back.matchduo.domain.chat.dto.response.ChatRoomSummaryResponse;
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatMessageRead;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.chat.repository.ChatMessageReadRepository;
+import com.back.matchduo.domain.chat.repository.ChatMessageRepository;
+import com.back.matchduo.domain.chat.repository.ChatRoomRepository;
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.gameaccount.repository.GameAccountRepository;
+import com.back.matchduo.domain.post.entity.Post;
+import com.back.matchduo.domain.post.repository.PostRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageReadRepository chatMessageReadRepository;
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final GameAccountRepository gameAccountRepository;
+
+    /**
+     * 채팅방 생성 (멱등)
+     * - 기존 방 있으면 재사용 (닫혀있으면 새 세션으로 재활성화)
+     * - 없으면 새로 생성
+     */
+    public ChatRoom createOrGet(Long postId, Long senderId) {
+        if (postId == null) {
+            throw new CustomException(CustomErrorCode.POST_ID_REQUIRED);
+        }
+        if (senderId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_USER_ID);
+        }
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.POST_NOT_FOUND));
+
+        // receiver = Post 작성자
+        User receiver = post.getUser();
+        if (receiver == null || receiver.getId() == null) {
+            throw new CustomException(CustomErrorCode.NOT_FOUND_USER);
+        }
+
+        User sender = userRepository.findById(senderId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER));
+
+        // 본인에게 채팅 불가
+        if (receiver.getId().equals(sender.getId())) {
+            throw new CustomException(CustomErrorCode.CHAT_SAME_SENDER_RECEIVER);
+        }
+
+        // 1) 기존 채팅방 조회
+        return chatRoomRepository.findByPostIdAndSenderId(postId, sender.getId())
+                .map(room -> {
+                    if (room.isClosed()) {
+                        // 닫힌 방이면 락 걸고 다시 조회후 재활성화
+                        ChatRoom lockedRoom = chatRoomRepository.findByPostIdAndSenderIdWithLock(postId, sender.getId())
+                                        .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
+                        if (lockedRoom.isClosed()) {
+                            lockedRoom.resumeAsNewSession();
+                            resetReadStates(lockedRoom, sender, receiver);
+                            return chatRoomRepository.save(lockedRoom);
+                        }
+                        return lockedRoom;
+                    }
+                    return room;
+                })
+                .orElseGet(() -> {
+                    // 2) 없으면 새 채팅방 생성 (동시성 레이스 대비)
+                    try {
+                        ChatRoom newRoom = ChatRoom.create(post, receiver, sender);
+                        ChatRoom saved = chatRoomRepository.save(newRoom);
+
+                        // (room, user) 당 1행: 읽음 상태 생성 (senderId, receiver 각각)
+                        chatMessageReadRepository.save(ChatMessageRead.create(saved, sender));
+                        chatMessageReadRepository.save(ChatMessageRead.create(saved, receiver));
+
+                        return saved;
+                    } catch (DataIntegrityViolationException e) {
+                        // UNIQUE(post_id, sender_id) 충돌 등 누군가가 동시에 먼저 생성한 경우
+                        ChatRoom existingRoom = chatRoomRepository.findByPostIdAndSenderId(postId, sender.getId())
+                                .orElseThrow(() -> e);
+
+                        // 닫혀있으면 재활성화
+                        if (existingRoom.isClosed()) {
+                            existingRoom.resumeAsNewSession();
+                            resetReadStates(existingRoom, sender, receiver);
+                            return chatRoomRepository.save(existingRoom);
+                        }
+                        return existingRoom;
+                    }
+                });
+    }
+
+    /**
+     * 채팅방 나가기
+     */
+    public ChatRoom leave(Long chatRoomId, Long userId) {
+        ChatRoom room = chatRoomRepository.findByIdWithLock(chatRoomId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
+        validateMember(room, userId);
+
+        room.leave(userId);
+        return chatRoomRepository.save(room);
+    }
+
+    /**
+     * 내 채팅방 목록 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ChatRoom> getMyRooms(Long userId, Long cursorId, int size) {
+        if (userId == null) throw new CustomException(CustomErrorCode.CHAT_INVALID_USER_ID);
+
+        int pageSize = (size <= 0 || size > 50) ? 20 : size;
+        Pageable pageable = PageRequest.of(0, pageSize);
+
+        return chatRoomRepository.findMyRooms(userId, cursorId, pageable);
+    }
+
+    /**
+     * 내 채팅방 목록 조회 (Summary 포함)
+     */
+    @Transactional(readOnly = true)
+    public List<ChatRoomSummaryResponse> getMyRoomsWithSummary(Long userId, Long cursorId, int size) {
+        List<ChatRoom> rooms = getMyRooms(userId, cursorId, size);
+
+        return rooms.stream()
+                .map(room -> {
+                    Integer sessionNo = room.getCurrentSessionNo();
+                    if (sessionNo == null) {
+                        sessionNo = 1;
+                    }
+
+                    // 마지막 메시지 조회
+                    ChatMessage lastMessage = chatMessageRepository
+                            .findFirstByChatRoomIdAndSessionNoOrderByIdDesc(room.getId(), sessionNo)
+                            .orElse(null);
+
+                    // 안 읽은 메시지 수 계산
+                    int unreadCount = 0;
+                    ChatMessageRead readState = chatMessageReadRepository
+                            .findByChatRoomIdAndUserId(room.getId(), userId)
+                            .orElse(null);
+
+                    if (readState != null && readState.getLastReadMessage() != null) {
+                        unreadCount = (int) chatMessageRepository.countUnread(
+                                room.getId(), sessionNo, readState.getLastReadMessage().getId());
+                    } else if (lastMessage != null) {
+                        // 읽은 메시지가 없으면 전체 메시지가 안 읽음
+                        unreadCount = (int) chatMessageRepository.countUnread(room.getId(), sessionNo, 0L);
+                    }
+
+                    return ChatRoomSummaryResponse.of(room, userId, lastMessage, unreadCount);
+                })
+                .toList();
+    }
+
+    /** 채팅방 상세 조회 (상대방 게임 계정 정보 포함) */
+    public ChatRoomDetailWithGameAccount getRoomWithGameAccount(Long chatRoomId, Long userId) {
+        ChatRoom room = getRoomOrThrow(chatRoomId);
+        validateMember(room, userId);
+
+        // 상대방 userId 구하기
+        boolean isSender = room.isSender(userId);
+        Long otherUserId = isSender ? room.getReceiver().getId() : room.getSender().getId();
+
+        // 상대방 게임 계정 조회 (LOL 계정)
+        GameAccount otherGameAccount = gameAccountRepository.findByUser_Id(otherUserId)
+                .stream()
+                .findFirst()
+                .orElse(null);
+
+        return new ChatRoomDetailWithGameAccount(room, otherGameAccount);
+    }
+
+    /**
+     * 헬퍼 메서드
+     */
+    private ChatRoom getRoomOrThrow(Long chatRoomId) {
+        if (chatRoomId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_CHAT_ROOM);
+        }
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    private void validateMember(ChatRoom room, Long userId) {
+        if (userId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_USER_ID);
+        }
+        room.getMemberRole(userId);
+    }
+
+    /**
+     * 새 세션 시작 시 읽음 상태 초기화
+     * - (room, user) 읽음 row가 없으면 생성해서 정합성을 보장
+     */
+    private void resetReadStates(ChatRoom room, User sender, User receiver) {
+        // 벌크 업데이트로 한 번에 초기화
+        chatMessageReadRepository.resetAllForRoom(room.getId());
+
+        // 없는 경우 생성 (새 채팅방인 경우)
+        getOrCreateReadState(room, sender);
+        getOrCreateReadState(room, receiver);
+    }
+
+    private ChatMessageRead getOrCreateReadState(ChatRoom room, User user) {
+        return chatMessageReadRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+                .orElseGet(() -> {
+                    try {
+                        return chatMessageReadRepository.save(ChatMessageRead.create(room, user));
+                    } catch (DataIntegrityViolationException e) {
+                        return chatMessageReadRepository.findByChatRoomIdAndUserId(room.getId(), user.getId())
+                                .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_READ_STATE_INVALID));
+                    }
+                });
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/back/matchduo/domain/chat/service/ChatRoomService.java
@@ -174,8 +174,9 @@ public class ChatRoomService {
     }
 
     /** 채팅방 상세 조회 (상대방 게임 계정 정보 포함) */
+    @Transactional(readOnly = true)
     public ChatRoomDetailWithGameAccount getRoomWithGameAccount(Long chatRoomId, Long userId) {
-        ChatRoom room = getRoomOrThrow(chatRoomId);
+        ChatRoom room = getRoomWithDetailsOrThrow(chatRoomId);
         validateMember(room, userId);
 
         // 상대방 userId 구하기
@@ -199,6 +200,15 @@ public class ChatRoomService {
             throw new CustomException(CustomErrorCode.CHAT_INVALID_CHAT_ROOM);
         }
         return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+
+    /** 채팅방 상세 조회 (sender, receiver, post 함께 로드) */
+    private ChatRoom getRoomWithDetailsOrThrow(Long chatRoomId) {
+        if (chatRoomId == null) {
+            throw new CustomException(CustomErrorCode.CHAT_INVALID_CHAT_ROOM);
+        }
+        return chatRoomRepository.findByIdWithDetails(chatRoomId)
                 .orElseThrow(() -> new CustomException(CustomErrorCode.CHAT_ROOM_NOT_FOUND));
     }
 

--- a/src/main/java/com/back/matchduo/domain/chat/service/ChatService.java
+++ b/src/main/java/com/back/matchduo/domain/chat/service/ChatService.java
@@ -1,9 +1,0 @@
-package com.back.matchduo.domain.chat.service;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-@Service
-@Transactional
-public class ChatService {
-}

--- a/src/main/java/com/back/matchduo/domain/chat/ws/ChatWebSocketController.java
+++ b/src/main/java/com/back/matchduo/domain/chat/ws/ChatWebSocketController.java
@@ -1,0 +1,64 @@
+package com.back.matchduo.domain.chat.ws;
+
+import com.back.matchduo.domain.chat.dto.request.ChatMessageSendRequest;
+import com.back.matchduo.domain.chat.dto.response.ChatMessageSendResponse;
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.service.ChatMessageService;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+
+import java.security.Principal;
+
+/**
+ * WebSocket 채팅 메시지
+ * - /pub/chats/{chatId}/messages -> 메시지 수신 후 /sub/chats/{chatId}로 브로드캐스트
+ */
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatWebSocketController {
+
+    private final ChatMessageService chatMessageService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /** WebSocket으로 메시지 전송 및 브로드캐스트 */
+    @MessageMapping("/chats/{chatId}/messages")
+    public void sendMessage(
+            @DestinationVariable Long chatId,
+            @Payload ChatMessageSendRequest request,
+            Principal principal
+    ) {
+        Long userId = extractUserId(principal);
+
+        // 메시지 저장
+        ChatMessage message = chatMessageService.send(
+                chatId, userId, request.messageType(), request.content());
+
+        ChatMessageSendResponse response = ChatMessageSendResponse.of(message);
+
+        // 해당 채팅방 구독자들에게 브로드캐스트
+        messagingTemplate.convertAndSend("/sub/chats/" + chatId, response);
+
+        log.debug("WebSocket 메시지 전송: chatId={}, senderId={}", chatId, userId);
+    }
+
+    private Long extractUserId(Principal principal) {
+        if (principal == null) {
+            throw new CustomException(CustomErrorCode.UNAUTHORIZED_USER);
+        }
+
+        if (principal instanceof Authentication auth) {
+            return (Long) auth.getPrincipal();
+        }
+
+        throw new CustomException(CustomErrorCode.UNAUTHORIZED_USER);
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/back/matchduo/domain/user/controller/UserProfileController.java
@@ -4,6 +4,7 @@ import com.back.matchduo.domain.user.dto.request.UserProfileRequest;
 import com.back.matchduo.domain.user.dto.request.UserUpdateRequest;
 import com.back.matchduo.domain.user.entity.User;
 import com.back.matchduo.domain.user.service.UserProfileService;
+import com.back.matchduo.global.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,34 +21,33 @@ public class UserProfileController {
     //프로필 조회
     @GetMapping
     public ResponseEntity<UserProfileRequest> getProfile(
-            @AuthenticationPrincipal User user
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        UserProfileRequest response = userProfileService.getProfile(user);
+        UserProfileRequest response = userProfileService.getProfile(userDetails.getUser());
         return ResponseEntity.ok(response);
     }
 
     //프로필 수정
     @PutMapping
     public ResponseEntity<Void> updateProfile(
-            @AuthenticationPrincipal
-            User user,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
 
             @Valid
             @RequestBody
             UserUpdateRequest request
     ) {
-        userProfileService.updateProfile(user, request);
+        userProfileService.updateProfile(userDetails.getUser(), request);
         return ResponseEntity.ok().build();
     }
 
     // 프로필 이미지 포함 수정
     @PutMapping("/all")
     public ResponseEntity<Void> updateProfileWithFile(
-            @AuthenticationPrincipal User user,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestPart(required = false) UserUpdateRequest request,
             @RequestPart(required = false) MultipartFile file // 추가할 부분
     ) {
-        userProfileService.updateProfileWithFile(user, request, file); // 추가할 부분
+        userProfileService.updateProfileWithFile(userDetails.getUser(), request, file); // 추가할 부분
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/back/matchduo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/back/matchduo/global/config/WebSocketConfig.java
@@ -1,0 +1,45 @@
+package com.back.matchduo.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import com.back.matchduo.global.security.websocket.StompAuthChannelInterceptor;
+
+/**
+ * WebSocket STOMP 설정
+ * - /ws: WebSocket 엔드포인트
+ * - /sub: 구독 prefix (서버 -> 클라이언트)
+ * - /pub: 발행 prefix (클라이언트 -> 서버)
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompAuthChannelInterceptor stompAuthChannelInterceptor;
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 클라이언트가 구독할 prefix (서버 -> 클라이언트)
+        registry.enableSimpleBroker("/sub");
+
+        // 클라이언트가 메시지 보낼 prefix (클라이언트 -> 서버)
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*") // CORS 설정
+                .withSockJS();                 // SockJS fallback
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(stompAuthChannelInterceptor);
+    }
+}

--- a/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
+++ b/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
@@ -56,11 +56,13 @@ public enum CustomErrorCode {
     INVALID_POST_MEMO(HttpStatus.BAD_REQUEST, "모집 내용은 1~50자이며 공백만 입력할 수 없습니다."),
     INVALID_LOOKING_POSITIONS(HttpStatus.BAD_REQUEST, "찾는 포지션 선택이 올바르지 않습니다."),
     INVALID_POST_STATUS_UPDATE(HttpStatus.BAD_REQUEST, "상태 변경은 FINISHED만 요청할 수 있습니다."),
+    POST_ID_REQUIRED(HttpStatus.BAD_REQUEST, "postId는 필수입니다."),
 
 
     // 5. Chat (채팅)
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
     CHAT_ROOM_CLOSED(HttpStatus.BAD_REQUEST, "종료된 채팅방에는 메시지를 보낼 수 없습니다."),
+    CHAT_ROOM_ALREADY_OPEN(HttpStatus.BAD_REQUEST, "이미 열려있는 채팅방입니다."),
     CHAT_SAME_SENDER_RECEIVER(HttpStatus.BAD_REQUEST, "채팅방의 sender와 receiver는 동일할 수 없습니다."),
     CHAT_INVALID_USER_ID(HttpStatus.BAD_REQUEST, "유효하지 않은 사용자 ID입니다."),
     CHAT_INVALID_CHAT_ROOM(HttpStatus.BAD_REQUEST, "채팅방 정보가 올바르지 않습니다."),
@@ -72,6 +74,7 @@ public enum CustomErrorCode {
     CHAT_INVALID_SESSION(HttpStatus.BAD_REQUEST, "메시지의 세션 정보가 올바르지 않습니다."),
     CHAT_READ_STATE_INVALID(HttpStatus.INTERNAL_SERVER_ERROR, "읽음 상태의 채팅방 정보가 올바르지 않습니다."),
     CHAT_USER_NOT_IN_ROOM(HttpStatus.FORBIDDEN, "해당 채팅방의 참여자가 아닙니다."),
+    CHAT_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅 메시지를 찾을 수 없습니다"),
 
     // 6. GameAccount (게임 계정)
     GAME_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "게임 계정을 찾을 수 없습니다."),

--- a/src/main/java/com/back/matchduo/global/security/AuthPrincipal.java
+++ b/src/main/java/com/back/matchduo/global/security/AuthPrincipal.java
@@ -17,7 +17,15 @@ public class AuthPrincipal {
             throw new CustomException(CustomErrorCode.UNAUTHORIZED_USER);
         }
 
-        return (Long) authentication.getPrincipal();
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof CustomUserDetails) {
+            return ((CustomUserDetails) principal).getId();
+        } else if (principal instanceof Long) {
+            return (Long) principal;
+        }
+
+        throw new CustomException(CustomErrorCode.UNAUTHORIZED_USER);
     }
 }
 

--- a/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.back.matchduo.global.security;
 
+import com.back.matchduo.domain.user.repository.UserRepository;
 import com.back.matchduo.global.config.CookieProperties;
 import com.back.matchduo.global.config.JwtProperties;
 import com.back.matchduo.global.security.filter.JwtAuthenticationFilter;
@@ -24,6 +25,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
             JwtProvider jwtProvider,
+            UserRepository userRepository,
             CorsConfigurationSource corsConfigurationSource
     ) throws Exception {
 
@@ -83,6 +85,7 @@ public class SecurityConfig {
                         // 예: 모집글 목록/상세, 게임모드 목록 등
                         // .requestMatchers("/api/v1/posts/**").permitAll()
                         .requestMatchers(
+                                "/api/v1/chats/**",
                                 "/ws/**"
                         ).permitAll()
 
@@ -92,7 +95,7 @@ public class SecurityConfig {
 
                 // JWT 인증 필터 등록
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtProvider),
+                        new JwtAuthenticationFilter(jwtProvider, userRepository),
                         UsernamePasswordAuthenticationFilter.class
                 );
 

--- a/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
@@ -83,10 +83,6 @@ public class SecurityConfig {
                         // 예: 모집글 목록/상세, 게임모드 목록 등
                         // .requestMatchers("/api/v1/posts/**").permitAll()
                         .requestMatchers(
-                                "/swagger-ui/**",
-                                "/v3/api-docs",
-                                "/v3/api-docs/**",
-                                "/swagger-resources/**",
                                 "/ws/**"
                         ).permitAll()
 

--- a/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
@@ -82,6 +82,13 @@ public class SecurityConfig {
                         // TODO: 공개 API는 여기 추가
                         // 예: 모집글 목록/상세, 게임모드 목록 등
                         // .requestMatchers("/api/v1/posts/**").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/ws/**"
+                        ).permitAll()
 
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
@@ -84,10 +84,9 @@ public class SecurityConfig {
                         // TODO: 공개 API는 여기 추가
                         // 예: 모집글 목록/상세, 게임모드 목록 등
                         // .requestMatchers("/api/v1/posts/**").permitAll()
-                        .requestMatchers(
-                                "/api/v1/chats/**",
-                                "/ws/**"
-                        ).permitAll()
+
+                        // WebSocket 엔드포인트만 permitAll (STOMP 인증은 StompAuthChannelInterceptor에서 처리)
+                        .requestMatchers("/ws/**").permitAll()
 
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/back/matchduo/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/back/matchduo/global/security/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,8 @@
 package com.back.matchduo.global.security.filter;
 
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.security.CustomUserDetails;
 import com.back.matchduo.global.security.cookie.AuthCookieProvider;
 import com.back.matchduo.global.security.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
@@ -13,14 +16,15 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
 
-    public JwtAuthenticationFilter(JwtProvider jwtProvider) {
+    public JwtAuthenticationFilter(JwtProvider jwtProvider, UserRepository userRepository) {
         this.jwtProvider = jwtProvider;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -41,16 +45,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 // 토큰에서 userId 추출
                 Long userId = jwtProvider.getUserId(accessToken);
 
-                // Role 사용 안 함 → authorities 비워둠
-                UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userId,
-                                null,
-                                List.of()
-                        );
+                // DB에서 User 조회 후 CustomUserDetails 생성
+                User user = userRepository.findById(userId).orElse(null);
+                if (user != null) {
+                    CustomUserDetails userDetails = new CustomUserDetails(user);
 
-                // SecurityContext에 인증 정보 저장
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(
+                                    userDetails,
+                                    null,
+                                    userDetails.getAuthorities()
+                            );
+
+                    // SecurityContext에 인증 정보 저장
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
 
             } catch (Exception e) {
                 // 토큰이 잘못된 경우 인증 정보 제거

--- a/src/main/java/com/back/matchduo/global/security/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/back/matchduo/global/security/websocket/StompAuthChannelInterceptor.java
@@ -1,0 +1,120 @@
+package com.back.matchduo.global.security.websocket;
+
+import com.back.matchduo.domain.chat.repository.ChatRoomRepository;
+import com.back.matchduo.global.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageDeliveryException;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * WebSocket STOMP 인증/인가
+ * - CONNECT: JWT 토큰 검증
+ * - SUBSCRIBE: 채팅방 멤버 검증
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StompAuthChannelInterceptor implements ChannelInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private final ChatRoomRepository chatRoomRepository;
+
+    private static final Pattern CHAT_ROOM_PATTERN = Pattern.compile("/sub/chats/(\\d+)");
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) {
+            return message;
+        }
+
+        StompCommand command = accessor.getCommand();
+
+        // CONNECT: JWT 인증
+        if (StompCommand.CONNECT.equals(command)) {
+            authenticateConnection(accessor);
+        }
+
+        // SUBSCRIBE: 채팅방 멤버 검증
+        if (StompCommand.SUBSCRIBE.equals(command)) {
+            validateSubscription(accessor);
+        }
+
+        return message;
+    }
+
+    private void authenticateConnection(StompHeaderAccessor accessor) {
+        String token = accessor.getFirstNativeHeader("Authorization");
+
+        if (token == null || !token.startsWith("Bearer ")) {
+            log.warn("WebSocket 인증 실패: 토큰 없음");
+            throw new MessageDeliveryException("인증 토큰이 필요합니다.");
+        }
+
+        token = token.substring(7);
+
+        try {
+            jwtProvider.validate(token);
+            Long userId = jwtProvider.getUserId(token);
+
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                    userId,
+                    null,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+            accessor.setUser(auth);
+
+            log.debug("WebSocket 인증 성공: userId={}", userId);
+        } catch (Exception e) {
+            log.warn("WebSocket 인증 실패: {}", e.getMessage());
+            throw new MessageDeliveryException("인증 실패: " + e.getMessage());
+        }
+    }
+
+    private void validateSubscription(StompHeaderAccessor accessor) {
+        String destination = accessor.getDestination();
+        if (destination == null) {
+            return;
+        }
+
+        // 채팅방 구독인 경우만 검증
+        Matcher matcher = CHAT_ROOM_PATTERN.matcher(destination);
+        if (!matcher.matches()) {
+            return;
+        }
+
+        // 인증 확인
+        Authentication auth = (Authentication) accessor.getUser();
+        if (auth == null) {
+            log.warn("WebSocket 구독 실패: 인증 정보 없음");
+            throw new MessageDeliveryException("인증이 필요합니다.");
+        }
+
+        Long userId = (Long) auth.getPrincipal();
+        Long chatId = Long.parseLong(matcher.group(1));
+
+        // 채팅방 멤버 검증
+        boolean isMember = chatRoomRepository.existsByIdAndMember(chatId, userId);
+        if (!isMember) {
+            log.warn("WebSocket 구독 실패: 채팅방 멤버 아님 - chatId={}, userId={}", chatId, userId);
+            throw new MessageDeliveryException("채팅방에 접근 권한이 없습니다.");
+        }
+
+        log.debug("WebSocket 구독 성공: chatId={}, userId={}", chatId, userId);
+    }
+}

--- a/src/test/java/com/back/matchduo/PartyControllerTest.java
+++ b/src/test/java/com/back/matchduo/PartyControllerTest.java
@@ -78,7 +78,7 @@ class PartyControllerTest {
                 .email("leader@test.com")
                 .password("1234")
                 .nickname("파티장")
-                .verification_code("1234")
+                .verificationCode("1234")
                 .build();
         userRepository.save(leaderUser);
 
@@ -87,7 +87,7 @@ class PartyControllerTest {
                 .email("member@test.com")
                 .password("1234")
                 .nickname("파티원")
-                .verification_code("5678")
+                .verificationCode("5678")
                 .build();
         userRepository.save(memberUser);
 
@@ -123,11 +123,11 @@ class PartyControllerTest {
 
         // 7. 초대 대상 유저 생성
         targetUser1 = User.builder()
-                .email("target1@test.com").password("1234").nickname("초대대상1").verification_code("0000").build();
+                .email("target1@test.com").password("1234").nickname("초대대상1").verificationCode("0000").build();
         userRepository.save(targetUser1);
 
         targetUser2 = User.builder()
-                .email("target2@test.com").password("1234").nickname("초대대상2").verification_code("0000").build();
+                .email("target2@test.com").password("1234").nickname("초대대상2").verificationCode("0000").build();
         userRepository.save(targetUser2);
     }
 

--- a/src/test/java/com/back/matchduo/domain/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/back/matchduo/domain/chat/controller/ChatControllerTest.java
@@ -1,0 +1,260 @@
+package com.back.matchduo.domain.chat.controller;
+
+import com.back.matchduo.domain.chat.dto.internal.ChatMessagesWithRoom;
+import com.back.matchduo.domain.chat.dto.internal.ChatRoomDetailWithGameAccount;
+import com.back.matchduo.domain.chat.dto.request.ChatMessageReadRequest;
+import com.back.matchduo.domain.chat.dto.request.ChatMessageSendRequest;
+import com.back.matchduo.domain.chat.dto.request.ChatRoomCreateRequest;
+import com.back.matchduo.domain.chat.dto.response.ChatRoomSummaryResponse;
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatMessageRead;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.chat.entity.MessageType;
+import com.back.matchduo.domain.chat.service.ChatMessageService;
+import com.back.matchduo.domain.chat.service.ChatRoomService;
+import com.back.matchduo.domain.post.entity.GameMode;
+import com.back.matchduo.domain.post.entity.Post;
+import com.back.matchduo.domain.post.entity.PostStatus;
+import com.back.matchduo.domain.post.entity.QueueType;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.global.security.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings("removal")
+@WebMvcTest(ChatController.class)
+class ChatControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockitoBean private ChatRoomService chatRoomService;
+    @MockitoBean private ChatMessageService chatMessageService;
+
+    private User postAuthor;
+    private User applicant;
+    private Post testPost;
+    private ChatRoom chatRoom;
+    private CustomUserDetails userDetails;
+
+    @BeforeEach
+    void setUp() {
+        postAuthor = User.builder()
+                .email("author@test.com")
+                .password("password123")
+                .nickname("작성자")
+                .verificationCode("1234")
+                .build();
+        ReflectionTestUtils.setField(postAuthor, "id", 1L);
+
+        applicant = User.builder()
+                .email("applicant@test.com")
+                .password("password123")
+                .nickname("지원자")
+                .verificationCode("5678")
+                .build();
+        ReflectionTestUtils.setField(applicant, "id", 2L);
+
+        testPost = mock(Post.class);
+        GameMode gameMode = mock(GameMode.class);
+        QueueType queueType = QueueType.DUO;
+        given(gameMode.getName()).willReturn("솔로 랭크");
+        given(testPost.getId()).willReturn(100L);
+        given(testPost.getUser()).willReturn(postAuthor);
+        given(testPost.getGameMode()).willReturn(gameMode);
+        given(testPost.getQueueType()).willReturn(queueType);
+        given(testPost.getStatus()).willReturn(PostStatus.RECRUITING);
+        given(testPost.getMemo()).willReturn("테스트 메모");
+
+
+        chatRoom = ChatRoom.create(testPost, postAuthor, applicant);
+        ReflectionTestUtils.setField(chatRoom, "id", 1L);
+
+        userDetails = new CustomUserDetails(applicant);
+    }
+
+    @Test
+    @DisplayName("채팅방 생성 API 성공")
+    void createChatRoom_success() throws Exception {
+        // given
+        ChatRoomCreateRequest request = new ChatRoomCreateRequest(100L);
+        given(chatRoomService.createOrGet(100L, 2L)).willReturn(chatRoom);
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/chats")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .with(csrf())
+                                .with(user(userDetails))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.chatRoomId").value(1L))
+                .andExpect(jsonPath("$.postId").value(100L));
+    }
+
+    @Test
+    @DisplayName("채팅방 목록 조회 API 성공")
+    void getChatRoomList_success() throws Exception {
+        // given
+        ChatRoomSummaryResponse summary = new ChatRoomSummaryResponse(
+                1L,
+                100L,
+                new ChatRoomSummaryResponse.OtherUserResponse(1L, "작성자", null),
+                null,
+                0,
+                "DUO",
+                "테스트 메모",
+                true,
+                null
+        );
+
+        given(chatRoomService.getMyRoomsWithSummary(2L, null, 21))
+                .willReturn(List.of(summary));
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/chats")
+                                .param("size", "20")
+                                .with(user(userDetails))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chatRooms").isArray())
+                .andExpect(jsonPath("$.chatRooms[0].chatRoomId").value(1L));
+    }
+
+    @Test
+    @DisplayName("메시지 전송 API 성공")
+    void sendMessage_success() throws Exception {
+        // given
+        ChatMessageSendRequest request = new ChatMessageSendRequest(MessageType.TEXT, "안녕하세요!");
+
+        ChatMessage message = ChatMessage.create(chatRoom, applicant, MessageType.TEXT, "안녕하세요!");
+        ReflectionTestUtils.setField(message, "id", 1L);
+        ReflectionTestUtils.setField(message, "createdAt", LocalDateTime.now());
+
+        given(chatMessageService.send(1L, 2L, MessageType.TEXT, "안녕하세요!"))
+                .willReturn(message);
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/chats/{chatId}/messages", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .with(csrf())
+                                .with(user(userDetails))
+                )
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.chatMessageId").value(1L))
+                .andExpect(jsonPath("$.content").value("안녕하세요!"));
+    }
+
+    @Test
+    @DisplayName("메시지 목록 조회 API 성공")
+    void getMessages_success() throws Exception {
+        // given
+        ChatMessage message = ChatMessage.create(chatRoom, applicant, MessageType.TEXT, "테스트 메시지");
+        ReflectionTestUtils.setField(message, "id", 1L);
+        ReflectionTestUtils.setField(message, "createdAt", LocalDateTime.now());
+
+        ChatMessagesWithRoom result = new ChatMessagesWithRoom(List.of(message), chatRoom);
+
+        given(chatMessageService.getMessagesWithRoom(1L, 2L, null, 31))
+                .willReturn(result);
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/chats/{chatId}/messages", 1L)
+                                .param("size", "30")
+                                .with(user(userDetails))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chatRoomId").value(1L))
+                .andExpect(jsonPath("$.messages[0].content").value("테스트 메시지"));
+    }
+
+    @Test
+    @DisplayName("채팅방 상세 조회 API 성공")
+    void getChatRoom_success() throws Exception {
+        // given
+        ChatRoomDetailWithGameAccount result = new ChatRoomDetailWithGameAccount(chatRoom, null);
+        given(chatRoomService.getRoomWithGameAccount(1L, 2L)).willReturn(result);
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/chats/{chatId}", 1L)
+                                .with(user(userDetails))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chatRoomId").value(1L))
+                .andExpect(jsonPath("$.otherUser.userId").value(1L))
+                .andExpect(jsonPath("$.otherUser.nickname").value("작성자"));
+    }
+
+    @Test
+    @DisplayName("채팅방 나가기 API 성공")
+    void leaveRoom_success() throws Exception {
+        // given - senderLeft=true이면 isClosed()가 true 반환
+        ReflectionTestUtils.setField(chatRoom, "senderLeft", true);
+        given(chatRoomService.leave(1L, 2L)).willReturn(chatRoom);
+
+        // when & then
+        mockMvc.perform(
+                        delete("/api/v1/chats/{chatId}", 1L)
+                                .with(csrf())
+                                .with(user(userDetails))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chatRoomId").value(1L))
+                .andExpect(jsonPath("$.isClosed").value(true));
+    }
+
+    @Test
+    @DisplayName("메시지 읽음 처리 API 성공")
+    void markAsRead_success() throws Exception {
+        // given
+        ChatMessageReadRequest request = new ChatMessageReadRequest(10L);
+
+        ChatMessage lastReadMessage = ChatMessage.create(chatRoom, postAuthor, MessageType.TEXT, "마지막 읽은 메시지");
+        ReflectionTestUtils.setField(lastReadMessage, "id", 10L);
+
+        ChatMessageRead readState = ChatMessageRead.create(chatRoom, applicant);
+        ReflectionTestUtils.setField(readState, "lastReadMessage", lastReadMessage);
+        ReflectionTestUtils.setField(readState, "lastReadAt", LocalDateTime.now());
+
+        given(chatMessageService.markReadUpTo(1L, 2L, 10L)).willReturn(readState);
+
+        // when & then
+        mockMvc.perform(
+                        post("/api/v1/chats/{chatId}/messages/read", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .with(csrf())
+                                .with(user(userDetails))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.chatRoomId").value(1L))
+                .andExpect(jsonPath("$.lastReadMessageId").value(10L));
+    }
+
+}

--- a/src/test/java/com/back/matchduo/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/chat/service/ChatServiceTest.java
@@ -1,0 +1,234 @@
+package com.back.matchduo.domain.chat.service;
+
+import com.back.matchduo.domain.chat.dto.internal.ChatMessagesWithRoom;
+import com.back.matchduo.domain.chat.dto.internal.ChatRoomDetailWithGameAccount;
+import com.back.matchduo.domain.chat.entity.ChatMessage;
+import com.back.matchduo.domain.chat.entity.ChatMessageRead;
+import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.chat.entity.MessageType;
+import com.back.matchduo.domain.post.entity.GameMode;
+import com.back.matchduo.domain.post.entity.Position;
+import com.back.matchduo.domain.post.entity.Post;
+import com.back.matchduo.domain.post.entity.QueueType;
+import com.back.matchduo.domain.post.repository.GameModeRepository;
+import com.back.matchduo.domain.post.repository.PostRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class ChatServiceTest {
+
+    @Autowired
+    private ChatRoomService chatRoomService;
+
+    @Autowired
+    private ChatMessageService chatMessageService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private GameModeRepository gameModeRepository;
+
+    private User postAuthor;
+    private User applicant;
+    private Post testPost;
+
+    @BeforeEach
+    void setUp() {
+        postAuthor = userRepository.save(User.builder()
+                .email("author@test.com")
+                .password("password123")
+                .nickname("작성자")
+                .verificationCode("1234")
+                .build());
+
+        applicant = userRepository.save(User.builder()
+                .email("applicant@test.com")
+                .password("password123")
+                .nickname("지원자")
+                .verificationCode("5678")
+                .build());
+
+        GameMode gameMode = gameModeRepository.findById(1L)
+                .orElseGet(() -> gameModeRepository.save(
+                        new GameMode("SOLO_RANK", "솔로 랭크", true)));
+
+        testPost = postRepository.save(Post.builder()
+                .user(postAuthor)
+                .gameMode(gameMode)
+                .queueType(QueueType.DUO)
+                .myPosition(Position.MID)
+                .lookingPositions("[\"TOP\", \"JUNGLE\"]")
+                .mic(true)
+                .recruitCount(1)
+                .memo("테스트 모집글")
+                .build());
+    }
+
+    @Nested
+    @DisplayName("채팅방 서비스")
+    class ChatRoomServiceTest {
+
+        @Test
+        @DisplayName("모집글을 통한 채팅방 생성 성공")
+        void createOrGet_success() {
+            // when
+            ChatRoom room = chatRoomService.createOrGet(testPost.getId(), applicant.getId());
+
+            // then
+            assertThat(room).isNotNull();
+            assertThat(room.getId()).isNotNull();
+            assertThat(room.getSender().getId()).isEqualTo(applicant.getId());
+            assertThat(room.getReceiver().getId()).isEqualTo(postAuthor.getId());
+        }
+
+        @Test
+        @DisplayName("채팅방 생성 멱등성 - 같은 요청 시 동일 채팅방 반환")
+        void createOrGet_idempotent() {
+            // given
+            ChatRoom room1 = chatRoomService.createOrGet(testPost.getId(), applicant.getId());
+
+            // when
+            ChatRoom room2 = chatRoomService.createOrGet(testPost.getId(), applicant.getId());
+
+            // then
+            assertThat(room1.getId()).isEqualTo(room2.getId());
+        }
+
+        @Test
+        @DisplayName("본인에게 채팅 시도 시 실패")
+        void createOrGet_fail_self_chat() {
+            assertThatThrownBy(() -> chatRoomService.createOrGet(testPost.getId(), postAuthor.getId()))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("채팅방 나가기 성공")
+        void leave_success() {
+            // given
+            ChatRoom room = chatRoomService.createOrGet(testPost.getId(), applicant.getId());
+
+            // when
+            ChatRoom leftRoom = chatRoomService.leave(room.getId(), applicant.getId());
+
+            // then
+            assertThat(leftRoom.isClosed()).isTrue();
+            assertThat(leftRoom.isSenderLeft()).isTrue();
+        }
+
+        @Test
+        @DisplayName("채팅방 조회 성공")
+        void getRoomWithGameAccount_success() {
+            // given
+            ChatRoom room = chatRoomService.createOrGet(testPost.getId(), applicant.getId());
+
+            // when
+            ChatRoomDetailWithGameAccount result = chatRoomService.getRoomWithGameAccount(room.getId(), applicant.getId());
+
+            // then
+            assertThat(result.room().getId()).isEqualTo(room.getId());
+        }
+
+        @Test
+        @DisplayName("참여하지 않은 사용자 채팅방 조회 실패")
+        void getRoomWithGameAccount_fail_not_member() {
+            // given
+            ChatRoom room = chatRoomService.createOrGet(testPost.getId(), applicant.getId());
+
+            User stranger = userRepository.save(User.builder()
+                    .email("stranger@test.com")
+                    .password("password123")
+                    .nickname("타인")
+                    .verificationCode("9999")
+                    .build());
+
+            // when & then
+            assertThatThrownBy(() -> chatRoomService.getRoomWithGameAccount(room.getId(), stranger.getId()))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("메시지 서비스")
+    class ChatMessageServiceTest {
+
+        private ChatRoom chatRoom;
+
+        @BeforeEach
+        void setUpChatRoom() {
+            chatRoom = chatRoomService.createOrGet(testPost.getId(), applicant.getId());
+        }
+
+        @Test
+        @DisplayName("메시지 전송 성공")
+        void send_success() {
+            // when
+            ChatMessage message = chatMessageService.send(
+                    chatRoom.getId(), applicant.getId(), MessageType.TEXT, "안녕하세요!");
+
+            // then
+            assertThat(message).isNotNull();
+            assertThat(message.getId()).isNotNull();
+            assertThat(message.getContent()).isEqualTo("안녕하세요!");
+        }
+
+        @Test
+        @DisplayName("닫힌 채팅방에 메시지 전송 실패")
+        void send_fail_closed_room() {
+            // given
+            chatRoomService.leave(chatRoom.getId(), applicant.getId());
+
+            // when & then
+            assertThatThrownBy(() -> chatMessageService.send(
+                    chatRoom.getId(), postAuthor.getId(), MessageType.TEXT, "메시지"))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("메시지 목록 조회 성공")
+        void getMessagesWithRoom_success() {
+            // given
+            chatMessageService.send(chatRoom.getId(), applicant.getId(), MessageType.TEXT, "메시지1");
+            chatMessageService.send(chatRoom.getId(), postAuthor.getId(), MessageType.TEXT, "메시지2");
+
+            // when
+            ChatMessagesWithRoom result = chatMessageService.getMessagesWithRoom(
+                    chatRoom.getId(), applicant.getId(), null, 10);
+
+            // then
+            assertThat(result.messages()).hasSize(2);
+            assertThat(result.room().getId()).isEqualTo(chatRoom.getId());
+        }
+
+        @Test
+        @DisplayName("메시지 읽음 처리 성공")
+        void markReadUpTo_success() {
+            // given
+            ChatMessage message = chatMessageService.send(
+                    chatRoom.getId(), applicant.getId(), MessageType.TEXT, "메시지");
+
+            // when
+            ChatMessageRead readState = chatMessageService.markReadUpTo(
+                    chatRoom.getId(), postAuthor.getId(), message.getId());
+
+            // then
+            assertThat(readState.getLastReadMessage().getId()).isEqualTo(message.getId());
+        }
+    }
+}


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #24 

## PR / 과제 설명 

- 모집글 기반 1:1 채팅 기능을 구현
- WebSocket를 통한 실시간 통신을 지원 

 ✔️  **채팅방 관리 (ChatRoomService)**
  | 기능 | 설명 |
  |------|------|
  | 채팅방 생성 | 모집글 ID + 지원자 ID로 1:1 채팅방 생성 |
  | 멱등성 보장 | 동일 조건 중복 요청 시 기존 채팅방 반환 |
  | 본인 채팅 방지 | 모집글 작성자가 본인에게 채팅 시도 시 예외 처리 |
  | 채팅방 나가기 | 한 명이라도 나가면 채팅방 닫힘 (메시지 전송 불가) |
  | 재입장 처리 | 닫힌 채팅방 재활성화 시 새 세션으로 시작 (과거 메시지 숨김) |
  | 동시성 제어 | 비관적 락(PESSIMISTIC_WRITE)으로 레이스 컨디션 방지 |

---

✔️ **메시지 관리 (ChatMessageService)**
 | 기능 | 설명 |
  |------|------|
  | 메시지 전송 | TEXT, SYSTEM 타입 지원 |
  | 메시지 조회 | 커서 기반 페이징, 현재 세션 메시지만 조회 |
  | 읽음 처리 | 마지막 읽은 메시지 포인터 방식, 안 읽은 메시지 수 계산 |
  | 닫힌 방 검증 | 채팅방이 닫혀있으면 메시지 전송 차단 |

---

✔️ **REST API (ChatController)**
  | Method | Endpoint | 설명 |
  |--------|----------|------|
  | POST | `/api/v1/chats` | 채팅방 생성 (멱등성 보장) |
  | GET | `/api/v1/chats` | 내 채팅방 목록 조회 |
  | GET | `/api/v1/chats/{chatId}` | 채팅방 상세 조회 |
  | DELETE | `/api/v1/chats/{chatId}` | 채팅방 나가기 |
  | POST | `/api/v1/chats/{chatId}/messages` | 메시지 전송 |
  | GET | `/api/v1/chats/{chatId}/messages` | 메시지 목록 조회 |
  | POST | `/api/v1/chats/{chatId}/messages/read` | 읽음 처리 |

---

✔️ **WebSocket 구조**
  | 파일 | 설명 |
  |------|------|
  | `WebSocketConfig.java` | STOMP 설정 |
  | `ChatWebSocketController.java` | 실시간 메시지 핸들러 |
  | `StompAuthChannelInterceptor.java` | JWT 인증 + 채팅방 멤버 검증 |

---

✔️  **WebSocket 엔드포인트**
- 연결: ws://host/ws
- 구독: /sub/chats/{chatId}
- 발행: /pub/chats/{chatId}/messages
