### PR TITLE
[BE/feat] 유저 검색 도메인 구현

### DIFF
--- a/src/main/java/com/back/matchduo/domain/usersearch/controller/UserSearchController.java
+++ b/src/main/java/com/back/matchduo/domain/usersearch/controller/UserSearchController.java
@@ -1,0 +1,23 @@
+package com.back.matchduo.domain.usersearch.controller;
+
+import com.back.matchduo.domain.usersearch.service.UserSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import com.back.matchduo.domain.usersearch.dto.response.UserSearchListResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserSearchController {
+
+    private final UserSearchService userSearchService;
+
+    @GetMapping("/search")
+    public UserSearchListResponse searchUsers(
+            @RequestParam String nickname,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Integer size
+    ) {
+        return userSearchService.search(nickname, cursor, size);
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/usersearch/dto/response/UserSearchListResponse.java
+++ b/src/main/java/com/back/matchduo/domain/usersearch/dto/response/UserSearchListResponse.java
@@ -1,0 +1,33 @@
+package com.back.matchduo.domain.usersearch.dto.response;
+
+import java.util.List;
+
+public record UserSearchListResponse(
+        long totalCount,
+        List<UserDto> users,
+        Long nextCursor,
+        Boolean hasNext
+) {
+    public record UserDto(
+            Long userId,
+            String nickname,
+            String profileImageUrl,
+            String comment,
+            GameAccountDto gameAccount
+    ) {}
+
+    public record GameAccountDto(
+            boolean linked,
+            String gameName,
+            String tagLine,
+            String profileIconUrl
+    ) {
+        public static GameAccountDto notLinked() {
+            return new GameAccountDto(false, null, null, null);
+        }
+
+        public static GameAccountDto linked(String gameName, String tagLine, String profileIconUrl) {
+            return new GameAccountDto(true, gameName, tagLine, profileIconUrl);
+        }
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/usersearch/repository/UserSearchGameAccountQueryRepository.java
+++ b/src/main/java/com/back/matchduo/domain/usersearch/repository/UserSearchGameAccountQueryRepository.java
@@ -1,0 +1,28 @@
+package com.back.matchduo.domain.usersearch.repository;
+
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserSearchGameAccountQueryRepository {
+
+    private final EntityManager em;
+
+    public List<GameAccount> findLolAccountsByUserIds(List<Long> userIds) {
+        if (userIds == null || userIds.isEmpty()) return List.of();
+
+        return em.createQuery(
+                        "SELECT ga FROM GameAccount ga " +
+                                "JOIN FETCH ga.user u " +
+                                "WHERE u.id IN :ids AND ga.gameType = 'LEAGUE_OF_LEGENDS'",
+                        GameAccount.class
+                )
+                .setParameter("ids", userIds)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/usersearch/repository/UserSearchQueryRepository.java
+++ b/src/main/java/com/back/matchduo/domain/usersearch/repository/UserSearchQueryRepository.java
@@ -1,0 +1,42 @@
+package com.back.matchduo.domain.usersearch.repository;
+
+import com.back.matchduo.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserSearchQueryRepository {
+
+    private final EntityManager em;
+
+    public List<User> findUsers(String nickname, Long cursor, int limit) {
+        String jpql =
+                "SELECT u FROM User u " +
+                        "WHERE u.nickname LIKE :keyword " +
+                        (cursor != null ? "AND u.id < :cursor " : "") +
+                        "ORDER BY u.id DESC";
+
+        var query = em.createQuery(jpql, User.class)
+                .setParameter("keyword", "%" + nickname + "%")
+                .setMaxResults(limit);
+
+        if (cursor != null) {
+            query.setParameter("cursor", cursor);
+        }
+
+        return query.getResultList();
+    }
+
+    public long countUsers(String nickname) {
+        return em.createQuery(
+                        "SELECT COUNT(u) FROM User u WHERE u.nickname LIKE :keyword",
+                        Long.class
+                )
+                .setParameter("keyword", "%" + nickname + "%")
+                .getSingleResult();
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/usersearch/service/UserSearchService.java
+++ b/src/main/java/com/back/matchduo/domain/usersearch/service/UserSearchService.java
@@ -1,0 +1,94 @@
+package com.back.matchduo.domain.usersearch.service;
+
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.post.service.PostGameProfileIconUrlBuilder;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.usersearch.dto.response.UserSearchListResponse;
+import com.back.matchduo.domain.usersearch.repository.UserSearchGameAccountQueryRepository;
+import com.back.matchduo.domain.usersearch.repository.UserSearchQueryRepository;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserSearchService {
+
+    private final UserSearchQueryRepository userSearchQueryRepository;
+    private final UserSearchGameAccountQueryRepository gameAccountQueryRepository;
+    private final PostGameProfileIconUrlBuilder iconUrlBuilder;
+
+    public UserSearchListResponse search(String nickname, Long cursor, Integer size) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new CustomException(CustomErrorCode.INVALID_SEARCH_KEYWORD);
+        }
+
+        int pageSize = (size == null || size <= 0) ? 10 : Math.min(size, 50);
+
+        long totalCount = userSearchQueryRepository.countUsers(nickname);
+
+        List<User> users = userSearchQueryRepository.findUsers(
+                nickname, cursor, pageSize + 1
+        );
+
+        boolean hasNext = users.size() > pageSize;
+        if (hasNext) {
+            users.remove(users.size() - 1);
+        }
+
+        Long nextCursor = hasNext && !users.isEmpty()
+                ? users.get(users.size() - 1).getId()
+                : null;
+
+        if (users.isEmpty()) {
+            return new UserSearchListResponse(totalCount, List.of(), null, false);
+        }
+
+        List<Long> userIds = users.stream().map(User::getId).toList();
+
+        List<GameAccount> accounts = gameAccountQueryRepository.findLolAccountsByUserIds(userIds);
+
+        Map<Long, GameAccount> accountByUserId = accounts.stream()
+                .collect(Collectors.toMap(
+                        ga -> ga.getUser().getId(),
+                        Function.identity(),
+                        (a, b) -> a
+                ));
+
+        List<UserSearchListResponse.UserDto> result = new ArrayList<>();
+
+        for (User u : users) {
+            GameAccount ga = accountByUserId.get(u.getId());
+
+            UserSearchListResponse.GameAccountDto gameAccountDto;
+
+            if (ga == null) {
+                gameAccountDto = UserSearchListResponse.GameAccountDto.notLinked();
+            } else {
+                String profileIconUrl = iconUrlBuilder.buildProfileIconUrl(ga.getProfileIconId());
+                gameAccountDto = UserSearchListResponse.GameAccountDto.linked(
+                        ga.getGameNickname(),
+                        ga.getGameTag(),
+                        profileIconUrl
+                );
+            }
+
+            result.add(new UserSearchListResponse.UserDto(
+                    u.getId(),
+                    u.getNickname(),
+                    u.getProfileImage(),
+                    u.getComment(),
+                    gameAccountDto
+            ));
+        }
+
+        return new UserSearchListResponse(totalCount, result, nextCursor, hasNext);
+    }
+}

--- a/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
+++ b/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
@@ -34,6 +34,9 @@ public enum CustomErrorCode {
     PASSWORD_INCONSISTENCY(HttpStatus.UNAUTHORIZED, "새 비밀번호가 일치하지 않습니다."),
     WRONG_CURRENT_PASSWORD(HttpStatus.UNAUTHORIZED, "현재 비밀번호가 올바르지 않습니다."),
 
+    // 3. Search (검색)
+    INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "검색어는 공백일 수 없습니다."),
+
     // 3. Party (파티)
     PARTY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 파티를 찾을 수 없습니다."),
     PARTY_ALREADY_CLOSED(HttpStatus.BAD_REQUEST, "이미 종료된 파티입니다."),


### PR DESCRIPTION
## 관련 이슈

- close #66 

## PR / 과제 설명 

# UserSearch 도메인 구현

## Controller
- **UserSearchController.java**
  - GET /api/v1/users/search 엔드포인트 구현
  - 커뮤니티 닉네임 검색 기능 (nickname, cursor, size 파라미터)

## Service
- **UserSearchService.java**
  - nickname 공백 검증 로직 추가 (INVALID_SEARCH_KEYWORD)
  - totalCount 제공 및 N+1 방지 (userId IN 일괄 조회)

## DTO
- **UserSearchListResponse.java**
  - totalCount, users, nextCursor, hasNext 응답 구조
  - UserDto: userId, nickname, profileImageUrl, comment, gameAccount
  - GameAccountDto: linked 여부에 따라 notLinked() / linked() 분기

## Repository
- **UserSearchQueryRepository.java**
  - nickname LIKE %keyword% 부분일치 검색 기능
  - userId DESC 정렬, 커서 기반 페이징 쿼리
  - totalCount 조회 쿼리 : 총 N명 찾았어요 반영

- **UserSearchGameAccountQueryRepository.java**
  - GameAccount 일괄 조회 (userId IN, gameType='LEAGUE_OF_LEGENDS')
  - User JOIN FETCH로 N+1 방지

## Global
- **CustomErrorCode.java**
  - Search : INVALID_SEARCH_KEYWORD (검색어 공백 검증)
  
- ### swagger API까지 확인했습니다
