### PR TITLE
[BE/refactor] 파티원 초대시 채팅 건 유저 목록 구현

### DIFF
--- a/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
@@ -1,6 +1,7 @@
 package com.back.matchduo.domain.chat.repository;
 
 import com.back.matchduo.domain.chat.entity.ChatRoom;
+import com.back.matchduo.domain.user.entity.User;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -58,4 +59,21 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
            "JOIN FETCH r.post p " +
            "WHERE r.id = :id")
     Optional<ChatRoom> findByIdWithDetails(@Param("id") Long id);
+
+    /**
+     * [파티 영입 후보 조회]
+     * 특정 모집글(Post)에 연결된 채팅방 중,
+     * 1. 방장(Receiver)이 '나(Leader)'인 방을 찾아서
+     * 2. 그 방의 상대방(Sender, 지원자)을 반환함.
+     * 3. 단, 상대방이 방을 나갔거나(senderLeft=true),
+     * 4. 이미 파티에 가입된 멤버(PartyMember)라면 제외함.
+     */
+    @Query("SELECT cr.sender FROM ChatRoom cr " +
+            "WHERE cr.post.id = :postId " +
+            "AND cr.receiver.id = :leaderId " +       // 방장은 나여야 함
+            "AND cr.senderLeft = false " +            // 상대가 방을 나갔으면 후보 아님
+            "AND cr.sender.id NOT IN (" +             // 이미 파티원인 사람은 제외
+            "   SELECT pm.user.id FROM PartyMember pm WHERE pm.party.postId = :postId"+
+            ")")
+    List<User> findCandidateUsers(@Param("postId") Long postId, @Param("leaderId") Long leaderId);
 }

--- a/src/main/java/com/back/matchduo/domain/party/controller/PartyController.java
+++ b/src/main/java/com/back/matchduo/domain/party/controller/PartyController.java
@@ -28,11 +28,10 @@ public class PartyController {
 
     // 1. 모집글 기준 파티 상세 정보 조회
     @GetMapping("/posts/{postId}/party")
-    @Operation(summary = "파티 상세 조회", description = "모집글의 파티 정보를 조회합니다.")
+    @Operation(summary = "파티 상세 조회", description = "모집글에 연결된 파티 정보와 참여 여부를 조회합니다.")
     public ResponseEntity<PartyByPostResponse> getPartyByPost(
             @PathVariable Long postId,
             @AuthenticationPrincipal CustomUserDetails userDetails
-            // isJoined 알기 위한
     ) {
         Long currentUserId = null;
         if (userDetails != null) {
@@ -46,6 +45,7 @@ public class PartyController {
 
     // 2. 파티원 초대
     @PostMapping("/parties/{partyId}/members")
+    @Operation(summary = "파티원 초대", description = "파티장이 다른 유저들을 파티에 초대(추가)합니다.")
     public ResponseEntity<List<PartyMemberAddResponse>> addPartyMember(
             @PathVariable Long partyId,
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -60,6 +60,7 @@ public class PartyController {
 
     // 3. 파티원 제외 (강퇴)
     @DeleteMapping("/parties/{partyId}/members/{memberId}")
+    @Operation(summary = "파티원 강퇴", description = "파티장이 특정 파티원을 파티에서 제외시킵니다.")
     public ResponseEntity<ApiResponse<PartyMemberRemoveResponse>> removePartyMember(
             @PathVariable Long partyId,
             @PathVariable Long memberId,
@@ -73,10 +74,13 @@ public class PartyController {
 
         PartyMemberRemoveResponse response = partyService.removeMember(partyId, memberId, currentUserId);
 
-        return ResponseEntity.ok(ApiResponse.ok("파티원이 제외되었습니다.", response));    }
+        return ResponseEntity.ok(ApiResponse.ok("파티원이 제외되었습니다.", response));
+    }
+
 
     // 4. 파티원 목록 조회
     @GetMapping("/parties/{partyId}/members")
+    @Operation(summary = "파티원 목록 조회", description = "특정 파티에 참여 중인 멤버 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<PartyMemberListResponse>> getPartyMemberList(
             @PathVariable Long partyId
     ) {
@@ -87,6 +91,7 @@ public class PartyController {
 
     // 5. 내가 참여한 파티 목록 조회
     @GetMapping("users/me/parties")
+    @Operation(summary = "내가 참여한 파티 목록 조회", description = "로그인한 사용자가 현재 참여하고 있는 파티 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<MyPartyListResponse>> getMyPartyList(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
@@ -99,8 +104,10 @@ public class PartyController {
         return ResponseEntity.ok(ApiResponse.ok("참여한 파티 목록을 조회했습니다.", response));
     }
 
+
     // 6. 파티 상태 수동 종료(파티장)
     @PatchMapping("/parties/{partyId}/close")
+    @Operation(summary = "파티 수동 종료", description = "파티장이 파티 모집을 수동으로 종료 상태로 변경합니다.")
     public ResponseEntity<ApiResponse<PartyCloseResponse>> closeParty(
             @PathVariable Long partyId,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -112,5 +119,22 @@ public class PartyController {
         PartyCloseResponse response = partyService.closeParty(partyId, userDetails.getId());
 
         return ResponseEntity.ok(ApiResponse.ok("파티가 종료되었습니다.", response));
+    }
+
+
+    // 7. 파티 영입 후보 조회 (채팅 건 유저 목록)
+    @GetMapping("/posts/{postId}/candidates")
+    @Operation(summary = "파티 영입 후보 조회", description = "해당 모집글에 채팅을 건 유저들 중, 아직 파티에 가입하지 않은 후보 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<ChatCandidateResponse>>> getChatCandidates(
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        if (userDetails == null) {
+            throw new CustomException(CustomErrorCode.UNAUTHORIZED_USER);
+        }
+
+        List<ChatCandidateResponse> response = partyService.getChatCandidates(postId, userDetails.getId());
+
+        return ResponseEntity.ok(ApiResponse.ok("영입 후보 목록을 조회했습니다.", response));
     }
 }

--- a/src/main/java/com/back/matchduo/domain/party/dto/response/ChatCandidateResponse.java
+++ b/src/main/java/com/back/matchduo/domain/party/dto/response/ChatCandidateResponse.java
@@ -1,0 +1,21 @@
+package com.back.matchduo.domain.party.dto.response;
+
+import com.back.matchduo.domain.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ChatCandidateResponse {
+    private Long userId;
+    private String nickname;
+    private String profileImage;
+
+    public static ChatCandidateResponse from(User user) {
+        return ChatCandidateResponse.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
+                .build();
+    }
+}


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #65 

## PR / 과제 설명 

### 1. 파티 영입 후보 조회 API 추가 (`GET`)
* **기능:** 특정 모집글(`postId`)을 보고 채팅을 걸어온 유저들 중, **아직 파티에 가입하지 않은 유저 목록**을 반환하는 API를 구현했습니다.
* **주요 로직:**
    * `ChatRoomRepository`를 통해 해당 모집글의 채팅방 대화 상대(`sender`)를 조회합니다.
    * 채팅방을 나간 유저(`senderLeft=true`)와 이미 파티에 가입된 멤버(`PartyMember`)는 목록에서 제외됩니다.
* **보안 강화:** `PartyService` 계층에 **방장 검증 로직**을 추가하여, 모집글 작성자가 아닌 유저가 API를 호출할 경우 `403 Forbidden` 예외(`NOT_PARTY_LEADER`)가 발생하도록 처리했습니다.

### 2. Swagger API 문서화 개선 (`@Operation`)
* `PartyController` 내의 모든 API 엔드포인트에 Swagger 설정을 적용했습니다.
* 각 API의 역할과 의도를 명확히 전달하기 위해 `summary`(요약)와 `description`(상세 설명)을 구체적으로 작성했습니다.

### 3. 테스트 코드 작성 (`PartyControllerTest`)
* 신규 API(`GET /candidates`)에 대한 컨트롤러 단위 테스트(Slice Test)를 작성했습니다.
* **검증 항목:**
    * ✅ **성공:** 채팅 이력이 있는 미가입 유저가 정상적으로 조회되는지 확인.
    * 🔒 **권한 검증:** 파티장이 아닌 유저가 요청 시 에러 응답을 반환하는지 확인.
    * 📉 **예외:** 채팅 기록이 없을 경우 빈 리스트가 반환되는지 확인.