### PR TITLE
[BE/refactor]  모집글 생성시 -> 파티,자동 생성 구현

### DIFF
--- a/src/main/java/com/back/matchduo/domain/party/entity/PartyMember.java
+++ b/src/main/java/com/back/matchduo/domain/party/entity/PartyMember.java
@@ -3,6 +3,7 @@ package com.back.matchduo.domain.party.entity;
 import com.back.matchduo.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -51,6 +52,7 @@ public class PartyMember {
     private LocalDateTime leftAt;
 
 
+    @Builder
     public PartyMember(Party party, User user, PartyMemberRole role) {
         this.party = party;
         this.user = user;

--- a/src/main/java/com/back/matchduo/domain/post/controller/PostController.java
+++ b/src/main/java/com/back/matchduo/domain/post/controller/PostController.java
@@ -13,6 +13,7 @@ import com.back.matchduo.domain.post.entity.PostStatus;
 import com.back.matchduo.domain.post.entity.QueueType;
 import com.back.matchduo.domain.post.service.PostService;
 import com.back.matchduo.global.security.AuthPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -28,6 +29,7 @@ public class PostController {
     // 모집글 생성
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "모집글 생성", description = "새로운 듀오/파티 모집글을 생성합니다. (작성 시 파티 및 파티장이 자동으로 생성됩니다.)")
     public PostCreateResponse createPost(
             @Valid @RequestBody PostCreateRequest request
     ) {
@@ -38,6 +40,7 @@ public class PostController {
     // 모집글 목록 조회 (Cursor 기반 무한 스크롤)
     // 추가 필터: myPositions=TOP,JUNGLE (CSV), tier=DIAMOND (단일)
     @GetMapping
+    @Operation(summary = "모집글 목록 조회", description = "필터링 조건에 따라 모집글 목록을 커서 기반 페이징으로 조회합니다.")
     public PostListResponse getPostList(
             @RequestParam(required = false) Long cursor,
             @RequestParam(required = false) Integer size,
@@ -59,6 +62,7 @@ public class PostController {
 
     // 모집글 수정 (작성자만)
     @PatchMapping("/{postId}")
+    @Operation(summary = "모집글 수정", description = "작성자가 자신의 모집글 내용을 수정합니다.")
     public PostUpdateResponse updatePost(
             @PathVariable Long postId,
             @Valid @RequestBody PostUpdateRequest request
@@ -69,6 +73,7 @@ public class PostController {
 
     // 모집 상태 변경, FINISHED만 요청 가능
     @PatchMapping("/{postId}/status")
+    @Operation(summary = "모집글 상태 변경", description = "모집글의 상태를 변경합니다. (예: 모집 완료 처리)")
     public PostStatusUpdateResponse updatePostStatus(
             @PathVariable Long postId,
             @Valid @RequestBody PostStatusUpdateRequest request
@@ -79,6 +84,7 @@ public class PostController {
 
     // 모집글 단건 조회 (작성자 검증)
     @GetMapping("/{postId}")
+    @Operation(summary = "모집글 단건 조회", description = "특정 모집글의 상세 정보를 조회합니다.")
     public PostDetailResponse getPostDetail(
             @PathVariable Long postId
     ) {
@@ -88,6 +94,7 @@ public class PostController {
 
     // 모집글 삭제 (작성자만)
     @DeleteMapping("/{postId}")
+    @Operation(summary = "모집글 삭제", description = "작성자가 자신의 모집글을 삭제합니다.")
     public PostDeleteResponse deletePost(
             @PathVariable Long postId
     ) {

--- a/src/main/java/com/back/matchduo/domain/post/dto/response/PostCreateResponse.java
+++ b/src/main/java/com/back/matchduo/domain/post/dto/response/PostCreateResponse.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public record PostCreateResponse(
         Long postId,
+        Long partyId,
         Long gameModeId,
         String gameMode,
         QueueType queueType,
@@ -25,12 +26,14 @@ public record PostCreateResponse(
         List<PostParticipant> participants
 ) {
     public static PostCreateResponse of(Post post,
+                                        Long partyId,
                                         List<Position> lookingPositions,
                                         Integer currentParticipants,
                                         PostWriter writer,
                                         List<PostParticipant> participants) {
         return new PostCreateResponse(
                 post.getId(),
+                partyId,
                 post.getGameMode().getId(),
                 post.getGameMode().getModeCode(),
                 post.getQueueType(),

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -18,8 +18,8 @@ spring:
   mail:
     host: smtp.gmail.com
     port: 587
-    username: bjw7099@gmail.com
-    password: srzwfeatyyvnisgd
+    username: ryan12256a@gmail.com
+    password: cullzkffhjwujtvy
     properties:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #76 

## PR / 과제 설명 

## 📕 개요 (Summary)

기존에 모집글(`Post`)을 생성할 때 파티(`Party`) 데이터가 DB에 생성되지 않던 문제를 해결했습니다.
이제 **모집글 작성과 동시에 파티가 생성되고, 작성자가 파티장(LEADER)으로 자동 등록**됩니다.

## 🛠️ 주요 변경 사항 (Changes)

### 1. 파티 자동 생성 로직 구현 (`PostListFacade`)

* **기존:** 모집글만 저장하고, 응답값에만 가짜 파티 정보를 넣어 반환함.
* **변경:** `createPostWithPartyView` 메서드 내에서 **트랜잭션**으로 다음 과정을 묶어서 처리합니다.
1. `Post` 저장
2. `Party` 생성 및 저장 (모집글 ID 연결)
3. `PartyMember` 생성 및 저장 (작성자를 `LEADER`로 등록)


* **영향:** 프론트엔드에서 별도로 파티 생성 API를 호출할 필요 없이, 글 작성만 하면 파티 기능이 활성화됩니다.

### 2. 엔티티 수정 (`PartyMember`)

* `PartyMember` 엔티티의 생성자에 `@Builder` 어노테이션을 추가했습니다.
* 서비스 로직에서 빌더 패턴을 사용하여 객체를 생성할 때, `joinedAt`(가입일)과 `state`(상태)가 누락되지 않고 생성자 로직을 통해 정상적으로 초기화되도록 수정했습니다.

### 3. Swagger API 문서화 (`PostController`)

* `PostController`에  `@Operation`,어노테이션을 전면 적용

## 📸 테스트 결과 / 스크린샷

* **Swagger UI:** (모집글 생성 API 설명이 추가된 화면 캡처가 있다면 첨부)
* **동작 검증:**
1. `POST /api/v1/posts` 호출 (성공)
2. `GET /api/v1/posts/{postId}/party` 호출 시 **자동 생성된 파티 정보(partyId, LEADER 정보)**가 정상 조회됨을 확인.
<img width="1119" height="406" alt="image" src="https://github.com/user-attachments/assets/3035e3d0-6f2a-4860-819d-4892a6f08bba" />
<img width="1127" height="252" alt="image" src="https://github.com/user-attachments/assets/adb5d019-702e-40b3-99fa-58c377253955" />
