### PR TITLE
[BE/fix] 채팅방 목록 조회 및 나가기 쿼리 수정 

### DIFF
--- a/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/back/matchduo/domain/chat/repository/ChatRoomRepository.java
@@ -21,9 +21,11 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
            "JOIN FETCH r.post p " +
            "JOIN FETCH p.gameMode " +
            "JOIN FETCH r.receiver JOIN FETCH r.sender " +
-           "WHERE (r.receiver.id = :userId OR r.sender.id = :userId) " +
+           "WHERE (" +
+           "    (r.sender.id = :userId AND r.senderLeft = false) OR " +
+           "    (r.receiver.id = :userId AND r.receiverLeft = false)" +
+           ") " +
            "AND p.isActive = true " +
-           "AND NOT (r.senderLeft = true AND r.receiverLeft = true) " +
            "AND (:cursor IS NULL OR r.id < :cursor) " +
            "ORDER BY r.id DESC")
     List<ChatRoom> findMyRooms(@Param("userId") Long userId,
@@ -52,11 +54,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
             @Param("chatRoomId") Long chatRoomId,
             @Param("userId") Long userId);
 
-    /** 채팅방 상세 조회 (sender, receiver, post 함께 로드 - N+1 방지) */
+    /** 채팅방 상세 조회 (sender, receiver, post, gameMode 함께 로드 - N+1 방지) */
     @Query("SELECT r FROM ChatRoom r " +
            "JOIN FETCH r.sender " +
            "JOIN FETCH r.receiver " +
            "JOIN FETCH r.post p " +
+           "JOIN FETCH p.gameMode " +
            "WHERE r.id = :id")
     Optional<ChatRoom> findByIdWithDetails(@Param("id") Long id);
 


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #88 

## PR / 과제 설명 

1. 메시지 목록 조회 시 LazyInitializationException 발생 
2. 채팅방 나가기 후에도 목록에 표시되는 문제

이슈에 내용 더 작성했습니다.
