### PR TITLE
[BE/fix] CORS preflight OPTIONS 요청 허용

### DIFF
--- a/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
@@ -53,6 +53,9 @@ public class SecurityConfig {
 
                 // 인가 규칙
                 .authorizeHttpRequests(auth -> auth
+                        // CORS preflight 요청 허용
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+
                         .requestMatchers(
                                 "/",
                                 "/index.html",


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #105 

## PR / 과제 설명 

- Security 필터 체인에서 CorsFilter보다 먼저 다른 필터가 실행되어 OPTIONS 요청이 차단되는 경우가 있음 
- 이런 경우 명시적으로 OPTIONS 요청을 permitAll 로 설정하면 해결됨
