### PR TITLE
[BE/fix] CORS Swagger origin 허용 추가

### DIFF
--- a/src/main/java/com/back/matchduo/global/config/CorsConfig.java
+++ b/src/main/java/com/back/matchduo/global/config/CorsConfig.java
@@ -19,6 +19,7 @@ public class CorsConfig {
         
         configuration.setAllowedOrigins(List.of(
                 "https://matchmyduo.vercel.app",
+                "https://api.matchmyduo.shop",
                 "http://localhost:3000"));
         
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #107 

## PR / 과제 설명 
- CorsConfig에 `https://api.matchmyduo.shop` origin 추가
