### PR TITLE
[BE/feat] Redis 채팅 캐싱 및 스케줄러 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,10 @@ dependencies {
     implementation("org.springframework.security:spring-security-messaging")
 
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/matchduo/domain/chat/service/ChatScheduler.java
+++ b/src/main/java/com/back/matchduo/domain/chat/service/ChatScheduler.java
@@ -1,0 +1,67 @@
+package com.back.matchduo.domain.chat.service;
+
+
+import com.back.matchduo.domain.chat.repository.ChatMessageReadRepository;
+import com.back.matchduo.domain.chat.repository.ChatMessageRepository;
+import com.back.matchduo.domain.chat.repository.ChatRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatScheduler {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageReadRepository chatMessageReadRepository;
+    private final ChatUnreadCacheService chatUnreadCacheService;
+
+    /**
+     * 닫힌 채팅방 정리 (매일 새벽 3시)
+     *  - 양쪽 모두 나간 지 3일 이상된 채팅방 삭제
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupClosedChatRooms() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(3);
+
+        List<Long> roomIds = chatRoomRepository.findFullyClosedIdsBefore(threshold);
+
+        if (roomIds.isEmpty()) {
+            log.debug("정리 대상 채팅방 없음");
+            return;
+        }
+
+        log.info("닫힌 채팅방 {}개 정리 시작", roomIds.size());
+
+        // Redis 캐시 삭제
+        roomIds.forEach(chatUnreadCacheService::deleteByChatRoomId);
+
+        // FK 제약 때문에 자식 먼저 삭제
+        chatMessageReadRepository.deleteByRoomIds(roomIds);
+        chatMessageRepository.deleteByRoomIds(roomIds);
+        chatRoomRepository.deleteAllById(roomIds);
+
+        log.info("닫힌 채팅방 {}개 정리 완료", roomIds.size());
+    }
+
+    /**
+     * 오래된 메시지 정리 (매일 새벽 4시)
+     * - 7일 이상된 메시지 삭제
+     */
+    @Scheduled(cron = "0 0 4 * * *")
+    @Transactional
+    public void cleanupOldMessages() {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(7);
+        int deletedCount = chatMessageRepository.deleteOldMessages(threshold);
+
+        log.info("7일 이상 된 메시지 {}개 정리 완료", deletedCount);
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/chat/service/ChatUnreadCacheService.java
+++ b/src/main/java/com/back/matchduo/domain/chat/service/ChatUnreadCacheService.java
@@ -1,0 +1,88 @@
+package com.back.matchduo.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatUnreadCacheService {
+
+    private final RedisTemplate<String, Long> redisTemplate;
+
+    private static final String UNREAD_KEY_PREFIX = "chat:unread:";
+    private static final Duration TTL = Duration.ofDays(7);
+
+    private String buildKey(Long chatRoomId, Long userId) {
+        return UNREAD_KEY_PREFIX + chatRoomId + ":" + userId;
+    }
+
+    /** 메시지 전송 시 상대방 unread +1 **/
+    public void increment(Long chatRoomId, Long userId) {
+        try {
+            String key = buildKey(chatRoomId, userId);
+            redisTemplate.opsForValue().increment(key);
+            redisTemplate.expire(key, TTL);
+            log.debug("Redis unread 증가: key={}", key);
+        } catch (Exception e) {
+            log.warn("Redis increment 실패: {}", e.getMessage());
+        }
+    }
+
+    /** 읽음 처리 시 unread = 0 **/
+    public void reset(Long chatRoomId, Long userId) {
+        try {
+            String key = buildKey(chatRoomId, userId);
+            redisTemplate.opsForValue().set(key, 0L, TTL);
+            log.debug("Redis unread 초기화: key={}", key);
+        } catch (Exception e) {
+            log.warn("Redis reset 실패: {}", e.getMessage());
+        }
+    }
+
+    /** 조회: Redis 없으면 DB fallback **/
+    public int getOrSync(Long chatRoomId, Long userId, Supplier<Long> dbCounter) {
+        try {
+            String key = buildKey(chatRoomId, userId);
+            Long count = redisTemplate.opsForValue().get(key);
+
+            if (count == null) {
+                long dbCount = dbCounter.get();
+                redisTemplate.opsForValue().set(key, dbCount, TTL);
+                return (int) dbCount;
+            }
+            return count.intValue();
+        } catch (Exception e) {
+            log.warn("Redis 조회 실패, DB fallback: {}", e.getMessage());
+            return dbCounter.get().intValue();
+        }
+    }
+
+    /** 키 삭제 (채팅방 닫힐 때) **/
+    public void delete(Long chatRoomId, Long userId) {
+        try {
+            redisTemplate.delete(buildKey(chatRoomId, userId));
+        } catch (Exception e) {
+            log.warn("Redis delete 실패: {}", e.getMessage());
+        }
+    }
+
+    /** 채팅방 관련 모든 키 삭제 (스케줄러용) **/
+    public void deleteByChatRoomId(Long chatRoomId) {
+        try {
+            String pattern = UNREAD_KEY_PREFIX + chatRoomId + ":*";
+            var keys = redisTemplate.keys(pattern);
+            if (keys != null && !keys.isEmpty()) {
+                redisTemplate.delete(keys);
+                log.debug("Redis 채팅방 캐시 삭제: chatRoomId={}, count={}", chatRoomId, keys.size());
+            }
+        } catch (Exception e) {
+            log.warn("Redis deleteByChatRoomId 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/back/matchduo/domain/chat/ws/ChatWebSocketController.java
+++ b/src/main/java/com/back/matchduo/domain/chat/ws/ChatWebSocketController.java
@@ -45,9 +45,12 @@ public class ChatWebSocketController {
         ChatMessageSendResponse response = ChatMessageSendResponse.of(message);
 
         // 해당 채팅방 구독자들에게 브로드캐스트
-        messagingTemplate.convertAndSend("/sub/chats/" + chatRoomId, response);
-
-        log.debug("WebSocket 메시지 전송: chatRoomId={}, senderId={}", chatRoomId, userId);
+        try {
+            messagingTemplate.convertAndSend("/sub/chats/" + chatRoomId, response);
+            log.debug("WebSocket 메시지 전송 성공: chatRoomId={}, sender={}", chatRoomId, userId);
+        } catch (Exception e) {
+            log.error("WebSocket 메시지 브로드캐스트 실패: chatRoomId={}, senderId={}, error={}", chatRoomId, userId, e.getMessage());
+        }
     }
 
     private Long extractUserId(Principal principal) {

--- a/src/main/java/com/back/matchduo/global/config/RedisConfig.java
+++ b/src/main/java/com/back/matchduo/global/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package com.back.matchduo.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Long> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Long> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Long.class));
+        return template;
+    }
+}

--- a/src/main/java/com/back/matchduo/global/security/jwt/JwtProvider.java
+++ b/src/main/java/com/back/matchduo/global/security/jwt/JwtProvider.java
@@ -63,4 +63,15 @@ public class JwtProvider {
 
         return Long.parseLong(claims.getSubject());
     }
+
+    // 토큰 만료 시간 추출
+    public Long getExpiration(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return claims.getExpiration().getTime();
+    }
 }

--- a/src/main/java/com/back/matchduo/global/security/websocket/StompAuthChannelInterceptor.java
+++ b/src/main/java/com/back/matchduo/global/security/websocket/StompAuthChannelInterceptor.java
@@ -17,13 +17,15 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * WebSocket STOMP 인증/인가
- * - CONNECT: JWT 토큰 검증
+ * - CONNECT: JWT 토큰 검증 + 만료시간 저장
  * - SUBSCRIBE: 채팅방 멤버 검증
+ * - SEND: 토큰 만료 여부 재검증
  */
 @Slf4j
 @Component
@@ -45,7 +47,7 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
 
         StompCommand command = accessor.getCommand();
 
-        // CONNECT: JWT 인증
+        // CONNECT: JWT 인증 + 만료시간 저장
         if (StompCommand.CONNECT.equals(command)) {
             authenticateConnection(accessor);
         }
@@ -53,6 +55,11 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         // SUBSCRIBE: 채팅방 멤버 검증
         if (StompCommand.SUBSCRIBE.equals(command)) {
             validateSubscription(accessor);
+        }
+
+        // SEND: 토큰 만료 여부 재검증
+        if (StompCommand.SEND.equals(command)) {
+            validateTokenNotExpired(accessor);
         }
 
         return message;
@@ -78,6 +85,10 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
                     List.of(new SimpleGrantedAuthority("ROLE_USER"))
             );
             accessor.setUser(auth);
+
+            // 만료 시간만 세션에 저장
+            Long expirationTime = jwtProvider.getExpiration(token);
+            accessor.getSessionAttributes().put("tokenExpiration", expirationTime);
 
             log.debug("WebSocket 인증 성공: userId={}", userId);
         } catch (Exception e) {
@@ -116,5 +127,19 @@ public class StompAuthChannelInterceptor implements ChannelInterceptor {
         }
 
         log.debug("WebSocket 구독 성공: chatRoomId={}, userId={}", chatRoomId, userId);
+    }
+
+    private void validateTokenNotExpired(StompHeaderAccessor accessor) {
+        Map<String, Object> sessionAttributes = accessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            throw new MessageDeliveryException("세션 정보가 없습니다.");
+        }
+
+        Long expiration = (Long) sessionAttributes.get("tokenExpiration");
+        if (expiration == null || System.currentTimeMillis() > expiration) {
+            log.warn("WebSocket 토큰 만료");
+            throw new MessageDeliveryException("토큰이 만료되었습니다. 다시 연결해주세요.");
+        }
+
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,11 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PW}
   mail:
     host: smtp.gmail.com
     port: 587

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -55,5 +55,5 @@ custom:
 
   cookie:
     secure: true
-    sameSite: Lax
+    sameSite: None
     path: /


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #69 

## PR / 과제 설명 
 
### ✔️ Redis Unread Count 캐싱 
- 채팅 목록 조회 시 안 읽은 메시지 개수를 DB가 아닌 Redis에서 조회하여 DB 부하 감소 

  캐시 구조
  | 항목  | 값                                |
  |-------|-----------------------------------|
  | Key   | chat:unread:{chatRoomId}:{userId} |
  | Value | Long (안 읽은 메시지 개수)        |
  | TTL   | 7일                               |

  캐시 연동 흐름
  | 상황            | 동작                           | 메서드      |
  |-----------------|--------------------------------|-------------|
  | 메시지 전송     | 상대방 unread +1               | increment() |
  | 읽음 처리       | 내 unread = 0                  | reset()     |
  | 목록 조회       | Redis 조회, 없으면 DB fallback | getOrSync() |
  | 채팅방 나가기   | 캐시 삭제                      | delete()    |
  | 채팅방 재활성화 | 양쪽 캐시 초기화               | reset()     |

---

### ✔️ 채팅 정리 스케줄러 
- 불필요한 데이터 자동 정리 및 쿼리 성능 유지 

  | 작업               | 실행 시간  | 대상                    | 보존 기간 |
  |--------------------|------------|-------------------------|-----------|
  | 닫힌 채팅방 정리   | 매일 03:00 | 양쪽 모두 나간 채팅방   | 3일       |
  | 오래된 메시지 정리 | 매일 04:00 | 생성된 지 오래된 메시지 | 7일       |

  삭제 순서 (FK 제약 고려)
  Redis 캐시 → ChatMessageRead → ChatMessage → ChatRoom

---

### ✔️ 성능 최적화 

N+1 문제 해결 
- 기존: 채팅방 목록 조회 시 각 방마다 마지막 메시지, 읽음 상태 개별 조회
- 개선: 배치 쿼리로 한 번에 조회 

  | 메서드                   | 용도                    |
  |--------------------------|-------------------------|
  | findRecentByRoomIds()    | 마지막 메시지 배치 조회 |
  | findByRoomIdsAndUserId() | 읽음 상태 배치 조회     |

---

### ✔️ WebSocket 보안 강화 

**문제점**: STOMP CONNECT 이후 토큰이 만료되어도 메시지 전송 가능 

  해결
  | 시점    | 동작                                      |
  |---------|-------------------------------------------|
  | CONNECT | JWT 검증 + 만료시간 세션에 저장           |
  | SEND    | 저장된 만료시간과 현재 시간 비교하여 검증 |

---

### ✔️ Redis 설정 

application-dev.yml 에 추가된 내용 
```yml
  spring:
    data:
      redis:
        host: ${REDIS_HOST}
        port: ${REDIS_PORT}
        password: ${REDIS_PW}
```

