### PR TITLE
[BE/feat] 벤 처리된 사용자의 모집글 확인 불가

### DIFF
--- a/src/main/java/com/back/matchduo/domain/post/service/PostListFacade.java
+++ b/src/main/java/com/back/matchduo/domain/post/service/PostListFacade.java
@@ -19,6 +19,7 @@ import com.back.matchduo.domain.post.repository.PostListQueryRepository;
 import com.back.matchduo.domain.post.repository.PostPartyQueryRepository;
 import com.back.matchduo.domain.post.repository.PostRepository;
 import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserBanRepository;
 import com.back.matchduo.domain.user.repository.UserRepository;
 import com.back.matchduo.global.exeption.CustomErrorCode;
 import com.back.matchduo.global.exeption.CustomException;
@@ -40,6 +41,7 @@ public class PostListFacade {
 
     private final PostRepository postRepository;
     private final UserRepository userRepository;
+    private final UserBanRepository userBanRepository;
     private final EntityManager entityManager;
     private final ObjectMapper objectMapper;
 
@@ -174,6 +176,12 @@ public class PostListFacade {
         // tier normalize
         String normalizedTier = (tier == null || tier.isBlank()) ? null : tier.trim().toUpperCase();
 
+        // 벤된 유저 ID 목록 조회 (currentUserId가 null이면 빈 리스트)
+        List<Long> bannedUserIds = List.of();
+        if (currentUserId != null) {
+            bannedUserIds = userBanRepository.findBannedUserIds(currentUserId);
+        }
+
         // Post 목록 1번 조회 (size + 1)
         List<Post> posts = postListQueryRepository.findPosts(
                 cursor,
@@ -182,7 +190,8 @@ public class PostListFacade {
                 queueType,
                 gameMode,
                 myPositions.isEmpty() ? null : myPositions,
-                normalizedTier
+                normalizedTier,
+                bannedUserIds.isEmpty() ? null : bannedUserIds
         );
 
         boolean hasNext = posts.size() > pageSize;

--- a/src/main/java/com/back/matchduo/domain/user/repository/UserBanRepository.java
+++ b/src/main/java/com/back/matchduo/domain/user/repository/UserBanRepository.java
@@ -3,6 +3,8 @@ package com.back.matchduo.domain.user.repository;
 import com.back.matchduo.domain.user.entity.User;
 import com.back.matchduo.domain.user.entity.UserBan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +18,12 @@ public interface UserBanRepository extends JpaRepository<UserBan, Long> {
 
     // 차단 해제를 위한 단건 조회
     Optional<UserBan> findByFromUserAndToUser(User fromUser, User toUser);
+
+    // 양방향 벤된 유저 ID 목록 조회 (내가 벤한 사람 + 나를 벤한 사람)
+    @Query("SELECT DISTINCT CASE " +
+            "WHEN ub.fromUser.id = :userId THEN ub.toUser.id " +
+            "WHEN ub.toUser.id = :userId THEN ub.fromUser.id " +
+            "END FROM UserBan ub " +
+            "WHERE ub.fromUser.id = :userId OR ub.toUser.id = :userId")
+    List<Long> findBannedUserIds(@Param("userId") Long userId);
 }


### PR DESCRIPTION
close #125 
## PR / 과제 설명 
## 모집글 벤 필터링 기능 (Post Ban Filtering)

### PostListFacade
**벤 필터링 적용 (`getPostList`):**
- 벤된 유저 ID 목록 조회: `currentUserId`가 null이 아니면 `UserBanRepository.findBannedUserIds()`로 양방향 벤 관계 조회
- 양방향 벤 처리: 내가 벤한 사람 + 나를 벤한 사람 모두 포함
- 필터링 전달: 조회한 벤 목록을 `PostListQueryRepository.findPosts()`에 전달
- 빈 리스트 처리: 벤된 유저가 없으면 null 전달하여 필터링 조건 미적용

### Repository
**UserBanRepository:**
- 양방향 벤 조회 메서드 추가 (`findBannedUserIds`):
  - JPQL 쿼리로 양방향 벤 관계 조회
  - `fromUser = userId` 또는 `toUser = userId` 조건으로 내가 벤한 사람 + 나를 벤한 사람 모두 조회
  - CASE 문으로 벤 상대방의 ID만 추출
  - DISTINCT로 중복 제거

**PostListQueryRepository:**
- 벤 필터링 조건 추가 (`findPosts`):
  - `bannedUserIds` 파라미터 추가
  - JPQL에 `AND u.id NOT IN :bannedUserIds` 조건 추가
  - 빈 리스트 처리: `bannedUserIds`가 null이거나 비어있으면 조건 추가 안 함
  - DB 레벨 필터링으로 페이징 정확도 유지

**양방향 벤 처리:**
- A가 B를 벤한 경우: A는 B의 모집글을 못 봄, B도 A의 모집글을 못 봄
- B가 A를 벤한 경우: 동일하게 양방향 적용
- 쿼리: `(fromUser = A AND toUser = B) OR (fromUser = B AND toUser = A)` 관계가 있으면 서로의 모집글 제외

**비로그인 사용자 처리:**
- `currentUserId`가 null이면 벤 필터링 미적용
- 기존 동작 유지 (모든 모집글 조회 가능)



