### PR TITLE
[BE/refactor] JWT, Flyway, Rate Limiting 설정 개선

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,16 @@ dependencies {
     // Redis
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
 
+    // Rate Limiting
+    implementation("com.bucket4j:bucket4j-core:8.7.0")
+
+    // AWS S3
+    implementation("com.amazonaws:aws-java-sdk-s3:1.12.777")
+
+    // Flyway
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
+
 }
 
 tasks.withType<Test> {

--- a/src/main/java/com/back/matchduo/domain/usersearch/repository/UserSearchGameAccountQueryRepository.java
+++ b/src/main/java/com/back/matchduo/domain/usersearch/repository/UserSearchGameAccountQueryRepository.java
@@ -19,7 +19,7 @@ public class UserSearchGameAccountQueryRepository {
         return em.createQuery(
                         "SELECT ga FROM GameAccount ga " +
                                 "JOIN FETCH ga.user u " +
-                                "WHERE u.id IN :ids AND ga.gameType = 'LEAGUE_OF_LEGENDS'",
+                                "WHERE u.id IN :ids AND ga.gameType IN ('LEAGUE_OF_LEGENDS', '리그 오브 레전드')",
                         GameAccount.class
                 )
                 .setParameter("ids", userIds)

--- a/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
+++ b/src/main/java/com/back/matchduo/global/exeption/CustomErrorCode.java
@@ -11,6 +11,7 @@ public enum CustomErrorCode {
     // 1. Common (공통)
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 
     // 2. User (사용자)
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."),

--- a/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/matchduo/global/security/SecurityConfig.java
@@ -4,17 +4,18 @@ import com.back.matchduo.domain.user.repository.UserRepository;
 import com.back.matchduo.global.config.CookieProperties;
 import com.back.matchduo.global.config.JwtProperties;
 import com.back.matchduo.global.security.filter.JwtAuthenticationFilter;
+import com.back.matchduo.global.security.filter.RateLimitFilter;
 import com.back.matchduo.global.security.handler.JsonAccessDeniedHandler;
 import com.back.matchduo.global.security.handler.JsonAuthEntryPoint;
 import com.back.matchduo.global.security.jwt.JwtProvider;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
@@ -26,7 +27,8 @@ public class SecurityConfig {
             HttpSecurity http,
             JwtProvider jwtProvider,
             UserRepository userRepository,
-            CorsConfigurationSource corsConfigurationSource
+            CorsConfigurationSource corsConfigurationSource,
+            RateLimitFilter rateLimitFilter
     ) throws Exception {
 
         http
@@ -103,6 +105,12 @@ public class SecurityConfig {
 
                         // 나머지는 인증 필요
                         .anyRequest().authenticated()
+                )
+
+                // Rate Limit 필터 등록
+                .addFilterBefore(
+                        rateLimitFilter,
+                        UsernamePasswordAuthenticationFilter.class
                 )
 
                 // JWT 인증 필터 등록

--- a/src/main/java/com/back/matchduo/global/security/filter/RateLimitFilter.java
+++ b/src/main/java/com/back/matchduo/global/security/filter/RateLimitFilter.java
@@ -46,7 +46,7 @@ public class RateLimitFilter extends OncePerRequestFilter {
             Bucket bucket = buckets.computeIfAbsent(clientIp, this::createLoginBucket);
 
             if (!bucket.tryConsume(1)) {
-                log.warn("Rate limit exceeded for IP: {}", clientIp);
+                log.warn("로그인 요청 횟수 초과 - IP: {}", clientIp);
                 sendRateLimitResponse(response);
                 return;
             }

--- a/src/main/java/com/back/matchduo/global/security/filter/RateLimitFilter.java
+++ b/src/main/java/com/back/matchduo/global/security/filter/RateLimitFilter.java
@@ -1,10 +1,17 @@
 package com.back.matchduo.global.security.filter;
 
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -13,46 +20,47 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-/**
- * 로그인 API Rate Limiting 필터
- * - 무차별 대입 공격(Brute Force) 방지
- * - IP당 15분에 5회 요청 제한
- **/
+@Slf4j
 @Component
 public class RateLimitFilter extends OncePerRequestFilter {
 
     private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final int CAPACITY = 5;
-    private static final Duration REFILL_DURATION = Duration.ofMinutes(15);
+    private static final int LOGIN_ATTEMPT_LIMIT = 5;
+    private static final Duration LOGIN_REFILL_DURATION = Duration.ofMinutes(15);
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request,
-                                    HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
         String path = request.getRequestURI();
+        String method = request.getMethod();
 
-        // 로그인 엔드포인트만 Rate Limiting 적용
-        if ("/api/v1/auth/login".equals(path)) {
+        // 로그인 엔드포인트에만 Rate Limit 적용
+        if ("POST".equalsIgnoreCase(method) && "/api/v1/users/login".equals(path)) {
             String clientIp = getClientIp(request);
-            Bucket bucket = buckets.computeIfAbsent(clientIp, this::createBucket);
+            Bucket bucket = buckets.computeIfAbsent(clientIp, this::createLoginBucket);
 
-            if(bucket.tryConsume(1)) {
-                filterChain.doFilter(request, response);
-            } else {
-                response.setStatus(429);
-                response.setContentType("application/json;charset=UTF-8");
-                response.getWriter().write("{\"error\": \"로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.\"}");
+            if (!bucket.tryConsume(1)) {
+                log.warn("Rate limit exceeded for IP: {}", clientIp);
+                sendRateLimitResponse(response);
+                return;
             }
-        } else {
-            filterChain.doFilter(request, response);
         }
+
+        filterChain.doFilter(request, response);
     }
 
-    private Bucket createBucket(String key) {
-        return Bucket.builder()
-                .addLimit(limit -> limit.capacity(CAPACITY).refillIntervally(CAPACITY, REFILL_DURATION))
-                .build();
+    private Bucket createLoginBucket(String key) {
+        Bandwidth limit = Bandwidth.classic(
+                LOGIN_ATTEMPT_LIMIT,
+                Refill.intervally(LOGIN_ATTEMPT_LIMIT, LOGIN_REFILL_DURATION)
+        );
+        return Bucket.builder().addLimit(limit).build();
     }
 
     private String getClientIp(HttpServletRequest request) {
@@ -61,5 +69,20 @@ public class RateLimitFilter extends OncePerRequestFilter {
             return xForwardedFor.split(",")[0].trim();
         }
         return request.getRemoteAddr();
+    }
+
+    private void sendRateLimitResponse(HttpServletResponse response) throws IOException {
+        CustomErrorCode errorCode = CustomErrorCode.TOO_MANY_REQUESTS;
+
+        CustomErrorResponse errorResponse = CustomErrorResponse.builder()
+                .status(errorCode.getStatus().value())
+                .code(errorCode.name())
+                .message("로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.")
+                .build();
+
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
     }
 }

--- a/src/main/java/com/back/matchduo/global/security/filter/RateLimitFilter.java
+++ b/src/main/java/com/back/matchduo/global/security/filter/RateLimitFilter.java
@@ -1,0 +1,65 @@
+package com.back.matchduo.global.security.filter;
+
+import io.github.bucket4j.Bucket;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 로그인 API Rate Limiting 필터
+ * - 무차별 대입 공격(Brute Force) 방지
+ * - IP당 15분에 5회 요청 제한
+ **/
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    private static final int CAPACITY = 5;
+    private static final Duration REFILL_DURATION = Duration.ofMinutes(15);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        // 로그인 엔드포인트만 Rate Limiting 적용
+        if ("/api/v1/auth/login".equals(path)) {
+            String clientIp = getClientIp(request);
+            Bucket bucket = buckets.computeIfAbsent(clientIp, this::createBucket);
+
+            if(bucket.tryConsume(1)) {
+                filterChain.doFilter(request, response);
+            } else {
+                response.setStatus(429);
+                response.setContentType("application/json;charset=UTF-8");
+                response.getWriter().write("{\"error\": \"로그인 시도가 너무 많습니다. 15분 후 다시 시도해주세요.\"}");
+            }
+        } else {
+            filterChain.doFilter(request, response);
+        }
+    }
+
+    private Bucket createBucket(String key) {
+        return Bucket.builder()
+                .addLimit(limit -> limit.capacity(CAPACITY).refillIntervally(CAPACITY, REFILL_DURATION))
+                .build();
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xForwardedFor = request.getHeader("X-Forwarded-For");
+        if (xForwardedFor != null && !xForwardedFor.isEmpty()) {
+            return xForwardedFor.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,8 @@ spring:
         format_sql: true
         highlight_sql: true
         use_sql_comments: true
+  flyway:
+    enabled: false
   data:
     redis:
       host: ${REDIS_HOST}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -26,13 +26,17 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate # Flyway가 스키마 관리
     properties:
       hibernate:
         format_sql: false
         highlight_sql: false
         use_sql_comments: false
     show-sql: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true # 기존 DB에 적용 시 필요
+    locations: classpath:db/migration
 
 logging:
   level:
@@ -52,8 +56,8 @@ custom:
 
   jwt:
     secretPattern: ${JWT_SECRET}
-    accessExpireSeconds: 1209600
-    refreshExpireSeconds: 1209600
+    accessExpireSeconds: 3600
+    refreshExpireSeconds: 604800
 
   cookie:
     secure: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -51,8 +51,8 @@ logging:
 custom:
   jwt:
     secretPattern: ${JWT_SECRET}
-    accessExpireSeconds: 1209600
-    refreshExpireSeconds: 1209600
+    accessExpireSeconds: 3600
+    refreshExpireSeconds: 604800
   cookie:
     secure: false
     path: /

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,484 @@
+-- MySQL dump 10.13  Distrib 8.0.44, for Linux (aarch64)
+--
+-- Host: localhost    Database: matchduo_db
+-- ------------------------------------------------------
+-- Server version	8.0.44
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `chat_message`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `chat_message` (
+  `chat_message_id` bigint NOT NULL AUTO_INCREMENT,
+  `content` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` datetime(6) NOT NULL,
+  `message_type` enum('SYSTEM','TEXT') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `session_no` int NOT NULL,
+  `chat_room_id` bigint NOT NULL,
+  `sender_id` bigint NOT NULL,
+  PRIMARY KEY (`chat_message_id`),
+  KEY `idx_chat_message_room_session_message_id` (`chat_room_id`,`session_no`,`chat_message_id`),
+  KEY `idx_chat_message_room_session_created_at` (`chat_room_id`,`session_no`,`created_at`),
+  KEY `FKm92rh2bmfw19xcn7nj5vrixsi` (`sender_id`),
+  CONSTRAINT `FKj52yap2xrm9u0721dct0tjor9` FOREIGN KEY (`chat_room_id`) REFERENCES `chat_room` (`chat_room_id`),
+  CONSTRAINT `FKm92rh2bmfw19xcn7nj5vrixsi` FOREIGN KEY (`sender_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `chat_message_read`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `chat_message_read` (
+  `message_read_id` bigint NOT NULL AUTO_INCREMENT,
+  `last_read_at` datetime(6) DEFAULT NULL,
+  `chat_room_id` bigint NOT NULL,
+  `last_read_message_id` bigint DEFAULT NULL,
+  `user_id` bigint NOT NULL,
+  PRIMARY KEY (`message_read_id`),
+  UNIQUE KEY `uk_message_read_room_user` (`chat_room_id`,`user_id`),
+  KEY `idx_message_read_user` (`user_id`),
+  KEY `FK1419qt2k9lb7mh4or9688rq4x` (`last_read_message_id`),
+  CONSTRAINT `FK1419qt2k9lb7mh4or9688rq4x` FOREIGN KEY (`last_read_message_id`) REFERENCES `chat_message` (`chat_message_id`) ON DELETE SET NULL,
+  CONSTRAINT `FKi7nq8vtewwwu8k8mwt0k00phm` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`),
+  CONSTRAINT `FKm2gbc2dx4vee3g2uj0e0te9yk` FOREIGN KEY (`chat_room_id`) REFERENCES `chat_room` (`chat_room_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `chat_room`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `chat_room` (
+  `chat_room_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `current_session_no` int NOT NULL,
+  `receiver_left` bit(1) NOT NULL,
+  `sender_left` bit(1) NOT NULL,
+  `session_started_at` datetime(6) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `post_id` bigint NOT NULL,
+  `receiver_id` bigint NOT NULL,
+  `sender_id` bigint NOT NULL,
+  PRIMARY KEY (`chat_room_id`),
+  UNIQUE KEY `uk_chat_room_post_sender` (`post_id`,`sender_id`),
+  KEY `idx_chat_room_post` (`post_id`),
+  KEY `idx_chat_room_sender` (`sender_id`),
+  KEY `idx_chat_room_receiver` (`receiver_id`),
+  CONSTRAINT `FK5omnauewbg4ga8ey3w8u6d0dd` FOREIGN KEY (`sender_id`) REFERENCES `user` (`id`),
+  CONSTRAINT `FKckfxqm5ulopxi03vfxeqh7k4m` FOREIGN KEY (`receiver_id`) REFERENCES `user` (`id`),
+  CONSTRAINT `FKdedif34f1oocp49p9lxh3tglc` FOREIGN KEY (`post_id`) REFERENCES `post` (`post_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `favorite_champion`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `favorite_champion` (
+  `favorite_champion_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `champion_id` int NOT NULL,
+  `champion_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `losses` int NOT NULL,
+  `champion_rank` int NOT NULL,
+  `total_games` int NOT NULL,
+  `win_rate` double NOT NULL,
+  `wins` int NOT NULL,
+  `game_account_id` bigint NOT NULL,
+  PRIMARY KEY (`favorite_champion_id`),
+  UNIQUE KEY `UKohpkkjs6y9aga121968dtm2a2` (`game_account_id`,`champion_rank`),
+  CONSTRAINT `FKr22v5014bljhq1x9jbrfhvwkk` FOREIGN KEY (`game_account_id`) REFERENCES `game_account` (`game_account_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `game_account`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `game_account` (
+  `game_account_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `game_nickname` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `game_tag` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `game_type` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `profile_icon_id` int DEFAULT NULL,
+  `puuid` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `user_id` bigint NOT NULL,
+  PRIMARY KEY (`game_account_id`),
+  KEY `FK6cfiyosmkmtj2euuoe9t08h7w` (`user_id`),
+  CONSTRAINT `FK6cfiyosmkmtj2euuoe9t08h7w` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `game_mode`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `game_mode` (
+  `game_mode_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `is_active` bit(1) NOT NULL,
+  `mode_code` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `name` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  PRIMARY KEY (`game_mode_id`),
+  UNIQUE KEY `UKpt46av3rkfvpr146m0jsimv3s` (`mode_code`)
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `game_rank`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `game_rank` (
+  `rank_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `losses` int NOT NULL,
+  `queue_type` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `rank_division` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `tier` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `win_rate` double NOT NULL,
+  `wins` int NOT NULL,
+  `game_account_id` bigint NOT NULL,
+  PRIMARY KEY (`rank_id`),
+  KEY `FKmdxb87uag14j2q72gsrg5g3x8` (`game_account_id`),
+  CONSTRAINT `FKmdxb87uag14j2q72gsrg5g3x8` FOREIGN KEY (`game_account_id`) REFERENCES `game_account` (`game_account_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `match_history`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `match_history` (
+  `match_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `game_duration` int NOT NULL,
+  `game_start_timestamp` bigint NOT NULL,
+  `queue_id` int NOT NULL,
+  `riot_match_id` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `win` bit(1) NOT NULL,
+  `game_account_id` bigint NOT NULL,
+  PRIMARY KEY (`match_id`),
+  UNIQUE KEY `UKd4khpo6jdp33jgbm1y2ej534g` (`riot_match_id`,`game_account_id`),
+  KEY `FK8m229t2rltthvqo7dhb5mv1ej` (`game_account_id`),
+  CONSTRAINT `FK8m229t2rltthvqo7dhb5mv1ej` FOREIGN KEY (`game_account_id`) REFERENCES `game_account` (`game_account_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `match_participant`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `match_participant` (
+  `match_participant_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `assists` int NOT NULL,
+  `champion_id` int NOT NULL,
+  `champion_name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `cs` int NOT NULL,
+  `deaths` int NOT NULL,
+  `item0` int DEFAULT NULL,
+  `item1` int DEFAULT NULL,
+  `item2` int DEFAULT NULL,
+  `item3` int DEFAULT NULL,
+  `item4` int DEFAULT NULL,
+  `item5` int DEFAULT NULL,
+  `item6` int DEFAULT NULL,
+  `kda` double NOT NULL,
+  `kills` int NOT NULL,
+  `level` int NOT NULL,
+  `perks` text COLLATE utf8mb4_unicode_ci,
+  `puuid` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `spell1_id` int NOT NULL,
+  `spell2_id` int NOT NULL,
+  `game_account_id` bigint NOT NULL,
+  `match_id` bigint NOT NULL,
+  PRIMARY KEY (`match_participant_id`),
+  UNIQUE KEY `UKqdf51mw8f34ofyfd71vmdxi5y` (`match_id`,`game_account_id`),
+  KEY `FKsohhepnawxki2re4mgkfpvbks` (`game_account_id`),
+  CONSTRAINT `FKruxftmrsxiptqpog3cxl6wv5a` FOREIGN KEY (`match_id`) REFERENCES `match_history` (`match_id`),
+  CONSTRAINT `FKsohhepnawxki2re4mgkfpvbks` FOREIGN KEY (`game_account_id`) REFERENCES `game_account` (`game_account_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `notification`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `notification` (
+  `notification_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `is_read` bit(1) NOT NULL,
+  `message` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `read_at` datetime(6) DEFAULT NULL,
+  `target_id` bigint NOT NULL,
+  `title` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `type` enum('CHAT_EXIT','NEW_CHAT','RECRUITMENT_COMPLETED','REVIEW_REQUEST') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` bigint NOT NULL,
+  PRIMARY KEY (`notification_id`),
+  KEY `FKb0yvoep4h4k92ipon31wmdf7e` (`user_id`),
+  CONSTRAINT `FKb0yvoep4h4k92ipon31wmdf7e` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `party`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `party` (
+  `party_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `closed_at` datetime(6) DEFAULT NULL,
+  `expires_at` datetime(6) DEFAULT NULL,
+  `leader_id` bigint NOT NULL,
+  `post_id` bigint NOT NULL,
+  `status` enum('ACTIVE','CLOSED','RECRUIT') COLLATE utf8mb4_unicode_ci NOT NULL,
+  PRIMARY KEY (`party_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `party_member`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `party_member` (
+  `party_member_id` bigint NOT NULL AUTO_INCREMENT,
+  `joined_at` datetime(6) NOT NULL,
+  `left_at` datetime(6) DEFAULT NULL,
+  `role` enum('LEADER','MEMBER') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `state` enum('JOINED','LEFT') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `party_id` bigint NOT NULL,
+  `user_id` bigint NOT NULL,
+  PRIMARY KEY (`party_member_id`),
+  UNIQUE KEY `uk_party_member_user` (`party_id`,`user_id`),
+  KEY `FKrheb2ixn81y9crg562uxq9gjb` (`user_id`),
+  CONSTRAINT `FKctrpcp93h130dwe6j1jlhf960` FOREIGN KEY (`party_id`) REFERENCES `party` (`party_id`),
+  CONSTRAINT `FKrheb2ixn81y9crg562uxq9gjb` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `post`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `post` (
+  `post_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `game_mode` enum('ARENA','HOWLING_ABYSS','SUMMONERS_RIFT') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `looking_positions` json NOT NULL,
+  `memo` text COLLATE utf8mb4_unicode_ci,
+  `mic` bit(1) NOT NULL,
+  `my_position` enum('ADC','ANY','JUNGLE','MID','SUPPORT','TOP') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `queue_type` enum('DUO','FLEX','NORMAL') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `recruit_count` int NOT NULL,
+  `status` enum('ACTIVE','CLOSED','RECRUIT') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` bigint NOT NULL,
+  PRIMARY KEY (`post_id`),
+  KEY `FK72mt33dhhs48hf9gcqrq4fxte` (`user_id`),
+  CONSTRAINT `FK72mt33dhhs48hf9gcqrq4fxte` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `refresh_token`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `refresh_token` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `expires_at` datetime(6) NOT NULL,
+  `token` tinytext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `user_id` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_refresh_token_user_id` (`user_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `review`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `review` (
+  `review_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `content` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `emoji` enum('BAD','GOOD','NORMAL') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `post_id` bigint NOT NULL,
+  `review_request_id` bigint DEFAULT NULL,
+  `reviewee_id` bigint NOT NULL,
+  `reviewer_id` bigint NOT NULL,
+  PRIMARY KEY (`review_id`),
+  UNIQUE KEY `uk_review_reviewer_reviewee_post` (`reviewer_id`,`reviewee_id`,`post_id`),
+  KEY `FKrl7b0my7pmicpl5l591p7qdu7` (`post_id`),
+  KEY `FKex04qrw6rnhqgcx6a7fhav492` (`review_request_id`),
+  KEY `FKrxxkeo5xlq721tgwpnyfx326i` (`reviewee_id`),
+  CONSTRAINT `FKex04qrw6rnhqgcx6a7fhav492` FOREIGN KEY (`review_request_id`) REFERENCES `review_request` (`review_request_id`),
+  CONSTRAINT `FKrl7b0my7pmicpl5l591p7qdu7` FOREIGN KEY (`post_id`) REFERENCES `post` (`post_id`),
+  CONSTRAINT `FKrxxkeo5xlq721tgwpnyfx326i` FOREIGN KEY (`reviewee_id`) REFERENCES `user` (`id`),
+  CONSTRAINT `FKt58e9mdgxpl7j90ketlaosmx4` FOREIGN KEY (`reviewer_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `review_request`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `review_request` (
+  `review_request_id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `expires_at` datetime(6) NOT NULL,
+  `status` enum('COMPLETED','PENDING') COLLATE utf8mb4_unicode_ci NOT NULL,
+  `post_id` bigint NOT NULL,
+  `request_user_id` bigint NOT NULL,
+  PRIMARY KEY (`review_request_id`),
+  UNIQUE KEY `uk_review_request_post_user` (`post_id`,`request_user_id`),
+  KEY `FKi6fybm4ude799rrg8wj2i3abl` (`request_user_id`),
+  CONSTRAINT `FK3ak0tik0pid86c0tfrixbbga4` FOREIGN KEY (`post_id`) REFERENCES `post` (`post_id`),
+  CONSTRAINT `FKi6fybm4ude799rrg8wj2i3abl` FOREIGN KEY (`request_user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `user`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `user` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `comment` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `email` varchar(40) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `nickname` varchar(20) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `password` varchar(100) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `profile_image` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `verification_code` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UKob8kqyqqgmefl0aco34akdtpe` (`email`),
+  UNIQUE KEY `UKn4swgcf30j6bmtb4l4cjryuym` (`nickname`)
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `user_bans`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `user_bans` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL,
+  `deleted_at` datetime(6) DEFAULT NULL,
+  `is_active` bit(1) NOT NULL,
+  `updated_at` datetime(6) NOT NULL,
+  `from_user_id` bigint NOT NULL,
+  `to_user_id` bigint NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UKmnp4piipnh3wwmbbhlpxwrqpx` (`from_user_id`,`to_user_id`),
+  KEY `FKrr3old8ryw4df15s0s1yfnciy` (`to_user_id`),
+  CONSTRAINT `FKg6un4lwqegtnuey0iyhcnsupt` FOREIGN KEY (`from_user_id`) REFERENCES `user` (`id`),
+  CONSTRAINT `FKrr3old8ryw4df15s0s1yfnciy` FOREIGN KEY (`to_user_id`) REFERENCES `user` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `verification`
+--
+
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE IF NOT EXISTS `verification` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `code` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `expires_at` datetime(6) NOT NULL,
+  `verified` bit(1) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UK4w12b7ntrv8tuy104c1vkqqbk` (`email`)
+) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2025-12-26  2:57:20

--- a/src/main/resources/db/migration/V2__unify_game_type.sql
+++ b/src/main/resources/db/migration/V2__unify_game_type.sql
@@ -1,0 +1,4 @@
+-- 게임 타입 값 통일: '리그 오브 레전드' -> 'LEAGUE_OF_LEGENDS'
+UPDATE game_account 
+SET game_type = 'LEAGUE_OF_LEGENDS' 
+WHERE game_type = '리그 오브 레전드';


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #126 

## PR / 과제 설명 

프로덕션 환경의 보안 및 안정성 강화를 위한
JWT 토큰 정책, DB 스키마 관리 방식, Rate Limiting을 개선.

### ✔️ JWT 토큰 만료 시간 단축 

 **문제점**
기존 Access / Refresh Token 모두 14일로 설정.
토큰 탈취 시 공격자가 **14일 간** 사용자 권한으로 시스템 접근 가능.

  | 항목 | 변경 전 | 변경 후 |
  |------|---------|---------|
  | Access Token | 14일 | 1시간 |
  | Refresh Token | 14일 | 7일 |

**효과**
토큰 탈취 피해 기간: 14일 → 최대 1시간.
Access / Refresh Token 역할 분리로 보안 강화. 

### ✔️ Flyway 마이그레이션 도입 

**문제점**
기존 prod 환경에서 `ddl-auto: create` 사용.
앱 재시작 시 **모든 테이블 DROP 후 재생성** → 데이터 전체 삭제 위험.

  | 환경 | ddl-auto | Flyway | 설명 |
  |------|----------|--------|------|
  | dev | `update` | `false` | 개발 편의성 유지 |
  | prod | `validate` | `true` | 스키마 검증만, 변경은 Flyway가 관리 |

**효과**
프로덕션 데이터 보호.
스키마 변경 이력 Git으로 추적 → 엔티티-스키마 불일치 시 앱 시작 단계에서 조기 감지.

### ✔️ Rate Limiting 필터 등록 

**문제점**
로그인 API가 무차별 대입 공격에 무방비 상태. 

  | 항목 | 변경 전 | 변경 후 |
  |------|---------|---------|
  | RateLimitFilter |  -  | SecurityConfig 필터 체인 등록 |
  | 적용 대상 | - | `/api/v1/auth/login` |
  | 제한 정책 | - | IP당 15분에 5회 |

**효과**
로그인 Brute Force 공격 방지.
제한 초과 시 `429 Too many Requests` 응답.

### ✔️ 게임 계정 연동 여부 조회 오류 수정 

**문제점**
`GET /api/v1/users/search` 응답에서 게임 계정이 연동되어 있는데도 `linked: false` 반환.
원인 → gameType 조회 시 `LEAGUE_OF_LEGENDS`만 체크, `리그 오브 레전드`로 저장된 데이터 누락.

---

### ⚠️ 로컬 환경 마이그레이션 안내 

이번 PR에서 Flyway 마이그레이션이 도입되었습니다.

  | 파일 | 설명 |
  |------|------|
  | V1__init_schema.sql | 전체 테이블 스키마 정의 |
  | V2__unify_game_type.sql | gameType 값 통일 ('리그 오브 레전드' → 'LEAGUE_OF_LEGENDS') |

**환경별 동작**
 | 환경 | V1 (스키마) | V2 (데이터) |
  |------|-------------|-------------|
  | **dev** | `ddl-auto: update`가 자동 처리 | **수동 실행 필요** |
  | **prod** | Flyway 자동 실행 | Flyway 자동 실행 |

pull 받은 후 **V2만 실행**

```bash
docker exec -i matchduo_db-mysql mysql -uroot -ppassword123! matchduo_db -e "UPDATE game_account SET game_type = 'LEAGUE_OF_LEGENDS' WHERE game_type = '리그 오브 레전드';"
```
> v1은 Hibernate `ddl-auto: update`가 처리하므로 실행하지 않아도 됩니다.


### 수정 파일 

  | 파일 | 변경 내용 |
  |------|-----------|
  | `build.gradle.kts` | Flyway, AWS S3 의존성 추가 |
  | `application.yml` | JWT 만료 시간 수정 |
  | `application-dev.yml` | Flyway 비활성화 |
  | `application-prod.yml` | ddl-auto, Flyway, JWT 설정 |
  | `SecurityConfig.java` | RateLimitFilter 필터 체인 등록 |
  | `RateLimitFilter.java` | 로그인 Rate Limiting 필터 (신규) |
  | `V1__init_schema.sql` | 초기 스키마 마이그레이션 (신규) |
  | `UserSearchGameAccountQueryRepository.java` | gameType 조회 조건 수정 |
  | `V2__unify_game_type.sql` | gameType 값 통일 마이그레이션 (신규) |