### PR TITLE
[BE/feat] 닉네임 변경 시각 추가

### DIFF
--- a/src/main/java/com/back/matchduo/domain/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/back/matchduo/domain/user/dto/response/UserProfileResponse.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDateTime;
+
 public record UserProfileResponse(
         @Schema(description = "유저 ID", example = "1")
         Long id,
@@ -26,20 +28,24 @@ public record UserProfileResponse(
 
         @Schema(description = "자기소개", example = "자기 소개입니다")
         @Size(max = 40, message = "자기소개는 최대 40글자까지 작성할 수 있습니다.")
-        String comment
+        String comment,
+
+        @Schema(description = "닉네임 최근 수정 시각", example = "2025-01-01T12:00:00")
+        LocalDateTime nicknameUpdatedAt
 ) {
 
-    public static UserProfileResponse from(User user, String baseUrl) { // 수정한 부분
+    public static UserProfileResponse from(User user, String baseUrl) {
         String fullProfileImage = user.getProfileImage() == null
                 ? null
-                : baseUrl + user.getProfileImage(); // 수정한 부분
+                : baseUrl + user.getProfileImage();
 
         return new UserProfileResponse(
                 user.getId(),
                 user.getEmail(),
-                fullProfileImage, // 수정한 부분
+                fullProfileImage,
                 user.getNickname(),
-                user.getComment()
+                user.getComment(),
+                user.getNicknameUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/back/matchduo/domain/user/entity/User.java
+++ b/src/main/java/com/back/matchduo/domain/user/entity/User.java
@@ -4,6 +4,8 @@ import com.back.matchduo.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Builder
@@ -33,6 +35,10 @@ public class User extends BaseEntity {
     @Column(name = "verification_code", length = 100, nullable = true)
     private String verificationCode;
 
+    private LocalDateTime nicknameUpdatedAt;
+
+
+
     public static User createUser(String email, String password, String nickname) {
         return User.builder()
                 .email(email)
@@ -60,5 +66,9 @@ public class User extends BaseEntity {
 
     public void updateProfileImage(String profileImage) {
         this.profileImage = profileImage;
+    }
+
+    public void setNicknameUpdatedAt(LocalDateTime nicknameUpdatedAt) {
+        this.nicknameUpdatedAt = nicknameUpdatedAt;
     }
 }

--- a/src/main/java/com/back/matchduo/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/back/matchduo/domain/user/service/UserProfileService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -62,7 +63,11 @@ public class UserProfileService {
             throw new CustomException(CustomErrorCode.DUPLICATE_NICKNAME);
         }
 
+        //닉네임 저장
         currentUser.setNickname(nickname);
+
+        //닉네임 최근 수정 시각 저장
+        currentUser.setNicknameUpdatedAt(LocalDateTime.now());
     }
 
     // 자기소개 수정


### PR DESCRIPTION
## 관련 이슈

- close #133

## PR / 과제 설명 
닉네임 변경 최소 주기가 7일이라서 이를 위해 GET /api/v1/users/me의 Response body에nicknameUpdatedAt 프로퍼티를 추가. 이 프로퍼티의 값은 닉네임 최근 수정 시각으로 설정.