### PR TITLE
[BE/fix] 채팅 API 타임존 정보 누락 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+
 # 첫 번째 스테이지: 빌드 스테이지
 FROM gradle:jdk-21-and-23-graal-jammy AS builder
 
@@ -24,6 +25,9 @@ RUN ./gradlew bootJar --no-daemon -x test
 # 두 번째 스테이지: 실행 스테이지
 FROM container-registry.oracle.com/graalvm/jdk:23
 
+# 타임존 설정 (Asia/Seoul)
+ENV TZ=Asia/Seoul
+
 # 작업 디렉토리 설정
 WORKDIR /app
 
@@ -31,4 +35,4 @@ WORKDIR /app
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 # 실행할 JAR 파일 지정
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul", "app.jar"]

--- a/src/main/java/com/back/matchduo/global/config/JacksonConfig.java
+++ b/src/main/java/com/back/matchduo/global/config/JacksonConfig.java
@@ -1,0 +1,54 @@
+package com.back.matchduo.global.config;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Jackson 직렬화 설정
+ * - LocalDateTime을 ISO-8601 with timezone 형식으로 직렬화
+ * - 예: 2026-01-05T12:04:33.824913+09:00
+ */
+@Configuration
+public class JacksonConfig {
+
+    private static final ZoneId SERVER_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+        return builder -> builder.serializers(new LocalDateTimeWithOffsetSerializer());
+    }
+
+    /**
+     * LocalDateTime을 오프셋 포함 형식으로 직렬화하는 Serializer
+     */
+    public static class LocalDateTimeWithOffsetSerializer extends JsonSerializer<LocalDateTime> {
+
+        private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+
+        @Override
+        public void serialize(LocalDateTime value, JsonGenerator gen, SerializerProvider serializers)
+                throws IOException {
+            if (value == null) {
+                gen.writeNull();
+                return;
+            }
+            // LocalDateTime에 서버 타임존(Asia/Seoul) 적용 후 오프셋 포함 형식으로 직렬화
+            String formatted = value.atZone(SERVER_ZONE).format(FORMATTER);
+            gen.writeString(formatted);
+        }
+
+        @Override
+        public Class<LocalDateTime> handledType() {
+            return LocalDateTime.class;
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/global/config/JacksonConfigTest.java
+++ b/src/test/java/com/back/matchduo/global/config/JacksonConfigTest.java
@@ -1,0 +1,39 @@
+package com.back.matchduo.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DisplayName("JacksonConfig 테스트")
+class JacksonConfigTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("LocalDateTime이 오프셋 포함 형식으로 직렬화되어야 한다")
+    void localDateTime_shouldBeSerializedWithOffset() throws Exception {
+        // given
+        LocalDateTime testTime = LocalDateTime.of(2026, 1, 5, 12, 4, 33, 824913000);
+        TestDto dto = new TestDto(testTime);
+
+        // when
+        String json = objectMapper.writeValueAsString(dto);
+
+        // then
+        System.out.println("직렬화 결과: " + json);
+
+        // +09:00 오프셋이 포함되어야 함
+        assertThat(json).contains("+09:00");
+        assertThat(json).contains("2026-01-05T12:04:33");
+    }
+
+    record TestDto(LocalDateTime createdAt) {}
+}


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #157 
> 이슈에 추가 내용 작성했습니다.
## PR / 과제 설명 

**변경 사항**
- `JacksonConfig` 추가: 모든 `LocalDateTime` 직렬화 시 ISO-8601 + 오프셋 형식으로 변환
- `Dockerfile` 수정: 컨테이너/JVM 타임존을 `Asia/Seoul`로 설정 

**테스트**
- `JacksonConfig` 단위 테스트 통과 확인.