### PR TITLE
[BE/fix] 레거시 유저 로그인 실패 

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -15,6 +15,38 @@ spring:
         format_sql: true
         highlight_sql: false
         use_sql_comments: true
-cloud:
-  aws:
+  flyway:
     enabled: false
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: ${REDIS_PW}
+  mail:
+    host: test
+    port: 01010
+
+custom:
+  jwt:
+    secretPattern: ${JWT_SECRET}
+    accessExpireSeconds: 3600
+    refreshExpireSeconds: 604800
+  cookie:
+    secure: false
+    sameSite: Lax
+    path: /
+
+riot:
+  api:
+    base-url: test
+    key: test-mock-key
+
+logging:
+  level:
+    root: WARN
+    com.back.matchduo: INFO
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN
+    org.springframework.web: WARN
+    org.springframework.messaging: WARN
+    com.zaxxer.hikari: WARN

--- a/src/test/java/com/back/matchduo/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/back/matchduo/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,445 @@
+package com.back.matchduo.domain.auth.controller;
+
+import com.back.matchduo.domain.auth.dto.request.LoginRequest;
+import com.back.matchduo.domain.auth.refresh.entity.RefreshToken;
+import com.back.matchduo.domain.auth.refresh.repository.RefreshTokenRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.security.jwt.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Auth API 통합 테스트")
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    private User testUser;
+    private User bcryptUser;
+
+    private static final String TEST_EMAIL = "auth-test@test.com";
+    private static final String TEST_PASSWORD = "password123";
+    private static final String TEST_NICKNAME = "인증테스터";
+
+    private static final String BCRYPT_EMAIL = "bcrypt-test@test.com";
+    private static final String BCRYPT_PASSWORD = "securePassword123";
+    private static final String BCRYPT_NICKNAME = "BCrypt테스터";
+
+    @BeforeAll
+    void setUp() {
+        testUser = User.builder()
+                .email(TEST_EMAIL)
+                .password(TEST_PASSWORD)
+                .nickname(TEST_NICKNAME)
+                .verificationCode("VERIFIED")
+                .build();
+        userRepository.save(testUser);
+    }
+
+    @Nested
+    @DisplayName("로그인 API (POST /api/v1/auth/login)")
+    class Login {
+
+        @Test
+        @DisplayName("성공: 올바른 이메일과 비밀번호로 로그인")
+        void success_login() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest(TEST_EMAIL, TEST_PASSWORD);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.user.userId").value(testUser.getId()))
+                    .andExpect(jsonPath("$.user.email").value(TEST_EMAIL))
+                    .andExpect(jsonPath("$.user.nickname").value(TEST_NICKNAME))
+                    .andExpect(jsonPath("$.accessToken").exists())
+                    .andExpect(jsonPath("$.refreshToken").exists())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: 로그인 시 쿠키에 토큰이 설정된다")
+        void success_login_sets_cookies() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest(TEST_EMAIL, TEST_PASSWORD);
+
+            // when
+            MvcResult result = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            ).andReturn();
+
+            // then
+            // Set-Cookie 헤더가 여러 개일 수 있으므로 getHeaders 사용
+            var setCookieHeaders = result.getResponse().getHeaders("Set-Cookie");
+            assertThat(setCookieHeaders).isNotEmpty();
+            assertThat(setCookieHeaders.stream().anyMatch(h -> h.contains("accessToken"))).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 이메일로 로그인 시 404 Not Found")
+        void fail_email_not_found() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest("notexist@test.com", TEST_PASSWORD);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.code").value("NOT_FOUND_EMAIL"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 비밀번호로 로그인 시 401 Unauthorized")
+        void fail_wrong_password() throws Exception {
+            // given
+            LoginRequest request = new LoginRequest(TEST_EMAIL, "wrongPassword");
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("WRONG_PASSWORD"))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 갱신 API (POST /api/v1/auth/refresh)")
+    class Refresh {
+
+        @Test
+        @DisplayName("성공: 유효한 RefreshToken으로 AccessToken 갱신")
+        void success_refresh() throws Exception {
+            // given
+            String refreshToken = jwtProvider.createRefreshToken(testUser.getId());
+
+            // DB에 RefreshToken 저장
+            RefreshToken savedToken = RefreshToken.create(
+                    testUser.getId(),
+                    refreshToken,
+                    LocalDateTime.now().plusDays(7)
+            );
+            refreshTokenRepository.save(savedToken);
+
+            Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                            .cookie(refreshCookie)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.user.userId").value(testUser.getId()))
+                    .andExpect(jsonPath("$.user.email").value(TEST_EMAIL))
+                    .andExpect(jsonPath("$.accessToken").exists())
+                    .andExpect(header().exists("Set-Cookie"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: RefreshToken 쿠키 없이 요청 시 401 Unauthorized")
+        void fail_no_refresh_token() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 RefreshToken으로 요청 시 401 Unauthorized")
+        void fail_invalid_refresh_token() throws Exception {
+            // given
+            Cookie invalidCookie = new Cookie("refreshToken", "invalid.token.here");
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                            .cookie(invalidCookie)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: DB에 저장되지 않은 RefreshToken으로 요청 시 401 Unauthorized")
+        void fail_refresh_token_not_in_db() throws Exception {
+            // given
+            // 유효한 토큰이지만 DB에 저장하지 않음
+            String refreshToken = jwtProvider.createRefreshToken(testUser.getId());
+            Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/refresh")
+                            .cookie(refreshCookie)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("UNAUTHORIZED_USER"))
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃 API (POST /api/v1/auth/logout)")
+    class Logout {
+
+        @Test
+        @DisplayName("성공: 로그아웃 시 쿠키가 만료된다")
+        void success_logout() throws Exception {
+            // given
+            String refreshToken = jwtProvider.createRefreshToken(testUser.getId());
+
+            // DB에 RefreshToken 저장
+            RefreshToken savedToken = RefreshToken.create(
+                    testUser.getId(),
+                    refreshToken,
+                    LocalDateTime.now().plusDays(7)
+            );
+            refreshTokenRepository.save(savedToken);
+
+            Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/logout")
+                            .cookie(refreshCookie)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andDo(print());
+
+            // DB에서 RefreshToken 삭제 확인
+            assertThat(refreshTokenRepository.findByUserId(testUser.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("성공: RefreshToken 없이 로그아웃해도 정상 처리된다")
+        void success_logout_without_token() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/logout")
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 암호화 통합 테스트")
+    class PasswordEncryption {
+
+        @Test
+        @DisplayName("성공: BCrypt 해시 비밀번호로 로그인")
+        void success_login_with_bcrypt_password() throws Exception {
+            // given
+            String encodedPassword = passwordEncoder.encode(BCRYPT_PASSWORD);
+            bcryptUser = User.builder()
+                    .email(BCRYPT_EMAIL)
+                    .password(encodedPassword)
+                    .nickname(BCRYPT_NICKNAME)
+                    .verificationCode("VERIFIED")
+                    .build();
+            userRepository.save(bcryptUser);
+
+            LoginRequest request = new LoginRequest(BCRYPT_EMAIL, BCRYPT_PASSWORD);
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.user.userId").value(bcryptUser.getId()))
+                    .andExpect(jsonPath("$.user.email").value(BCRYPT_EMAIL))
+                    .andExpect(jsonPath("$.user.nickname").value(BCRYPT_NICKNAME))
+                    .andExpect(jsonPath("$.accessToken").exists())
+                    .andExpect(jsonPath("$.refreshToken").exists())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: BCrypt 해시 비밀번호 불일치")
+        void fail_login_with_wrong_bcrypt_password() throws Exception {
+            // given
+            String encodedPassword = passwordEncoder.encode(BCRYPT_PASSWORD);
+            User user = User.builder()
+                    .email("bcrypt-wrong@test.com")
+                    .password(encodedPassword)
+                    .nickname("BCrypt오류테스터")
+                    .verificationCode("VERIFIED")
+                    .build();
+            userRepository.save(user);
+
+            LoginRequest request = new LoginRequest("bcrypt-wrong@test.com", "wrongPassword");
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("WRONG_PASSWORD"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: 레거시 평문 비밀번호 로그인 후 BCrypt로 마이그레이션")
+        void success_login_with_legacy_password_and_migration() throws Exception {
+            // given
+            String plainPassword = "legacyPassword123";
+            User legacyUser = User.builder()
+                    .email("legacy@test.com")
+                    .password(plainPassword)  // 평문 비밀번호
+                    .nickname("레거시유저")
+                    .verificationCode("VERIFIED")
+                    .build();
+            userRepository.save(legacyUser);
+
+            LoginRequest request = new LoginRequest("legacy@test.com", plainPassword);
+
+            // when - 첫 번째 로그인 (마이그레이션 발생)
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.user.email").value("legacy@test.com"))
+                    .andDo(print());
+
+            // 비밀번호가 BCrypt로 마이그레이션되었는지 확인
+            User updatedUser = userRepository.findByEmail("legacy@test.com").orElseThrow();
+            assertThat(updatedUser.getPassword()).startsWith("$2");
+            assertThat(passwordEncoder.matches(plainPassword, updatedUser.getPassword())).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: 마이그레이션 후 BCrypt 비밀번호로 재로그인")
+        void success_relogin_after_migration() throws Exception {
+            // given
+            String plainPassword = "migrationTest123";
+            User legacyUser = User.builder()
+                    .email("migration-relogin@test.com")
+                    .password(plainPassword)  // 평문 비밀번호
+                    .nickname("마이그레이션재로그인")
+                    .verificationCode("VERIFIED")
+                    .build();
+            userRepository.save(legacyUser);
+
+            LoginRequest request = new LoginRequest("migration-relogin@test.com", plainPassword);
+
+            // 첫 번째 로그인 (마이그레이션 발생)
+            mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            ).andExpect(status().isOk());
+
+            // when - 두 번째 로그인 (BCrypt 비밀번호로)
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.user.email").value("migration-relogin@test.com"))
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/auth/service/AuthServiceIntegrationTest.java
+++ b/src/test/java/com/back/matchduo/domain/auth/service/AuthServiceIntegrationTest.java
@@ -1,0 +1,128 @@
+package com.back.matchduo.domain.auth.service;
+
+import com.back.matchduo.domain.auth.dto.request.LoginRequest;
+import com.back.matchduo.domain.auth.dto.response.LoginResponse;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DisplayName("AuthService 통합 테스트")
+class AuthServiceIntegrationTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @MockitoBean
+    private HttpServletResponse response;
+
+    @MockitoBean
+    private com.back.matchduo.global.security.cookie.AuthCookieProvider cookieProvider;
+
+    @Test
+    @Transactional
+    @DisplayName("레거시 평문 비밀번호 로그인 시 BCrypt로 마이그레이션되어 DB에 저장된다")
+    void login_legacy_password_migration_to_db() {
+        // given
+        String plainPassword = "testPassword123";
+
+        User legacyUser = User.builder()
+                .email("legacy-test@test.com")
+                .password(plainPassword)  // 평문 비밀번호로 저장
+                .nickname("레거시테스트")
+                .verificationCode("VERIFIED")
+                .build();
+
+        userRepository.save(legacyUser);
+
+        System.out.println("========== 레거시 비밀번호 마이그레이션 테스트 ==========");
+        System.out.println("[마이그레이션 전] 저장된 비밀번호: " + legacyUser.getPassword());
+
+        // Mock 설정 (쿠키 관련)
+        given(cookieProvider.createAccessTokenCookie(anyString(), anyLong()))
+                .willReturn(ResponseCookie.from("accessToken", "token").build());
+        given(cookieProvider.createRefreshTokenCookie(anyString(), anyLong()))
+                .willReturn(ResponseCookie.from("refreshToken", "token").build());
+
+        LoginRequest request = new LoginRequest("legacy-test@test.com", plainPassword);
+
+        // when
+        LoginResponse result = authService.login(request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.user().email()).isEqualTo("legacy-test@test.com");
+
+        // DB에서 다시 조회하여 비밀번호가 BCrypt로 변경되었는지 확인
+        User updatedUser = userRepository.findByEmail("legacy-test@test.com").orElseThrow();
+
+        System.out.println("[마이그레이션 후] 저장된 비밀번호: " + updatedUser.getPassword());
+        System.out.println("[검증] BCrypt 형식 여부: " + updatedUser.getPassword().startsWith("$2"));
+        System.out.println("[검증] 비밀번호 매칭: " + passwordEncoder.matches(plainPassword, updatedUser.getPassword()));
+        System.out.println("=====================================================");
+
+        // BCrypt 해시는 $2로 시작
+        assertThat(updatedUser.getPassword()).startsWith("$2");
+
+        // 변경된 비밀번호로 검증 가능한지 확인
+        assertThat(passwordEncoder.matches(plainPassword, updatedUser.getPassword())).isTrue();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("BCrypt 비밀번호 유저는 마이그레이션 없이 로그인 성공")
+    void login_bcrypt_password_no_migration() {
+        // given
+        String plainPassword = "testPassword123";
+        String encodedPassword = passwordEncoder.encode(plainPassword);
+
+        User bcryptUser = User.builder()
+                .email("bcrypt-test@test.com")
+                .password(encodedPassword)  // BCrypt로 저장
+                .nickname("BCrypt테스트")
+                .verificationCode("VERIFIED")
+                .build();
+
+        userRepository.save(bcryptUser);
+
+        // Mock 설정
+        given(cookieProvider.createAccessTokenCookie(anyString(), anyLong()))
+                .willReturn(ResponseCookie.from("accessToken", "token").build());
+        given(cookieProvider.createRefreshTokenCookie(anyString(), anyLong()))
+                .willReturn(ResponseCookie.from("refreshToken", "token").build());
+
+        LoginRequest request = new LoginRequest("bcrypt-test@test.com", plainPassword);
+
+        // when
+        LoginResponse result = authService.login(request, response);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.user().email()).isEqualTo("bcrypt-test@test.com");
+
+        // 비밀번호가 변경되지 않았는지 확인
+        User unchangedUser = userRepository.findByEmail("bcrypt-test@test.com").orElseThrow();
+        assertThat(unchangedUser.getPassword()).isEqualTo(encodedPassword);
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,293 @@
+package com.back.matchduo.domain.auth.service;
+
+import com.back.matchduo.domain.auth.dto.request.LoginRequest;
+import com.back.matchduo.domain.auth.dto.response.LoginResponse;
+import com.back.matchduo.domain.auth.refresh.repository.RefreshTokenRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.config.JwtProperties;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import com.back.matchduo.global.security.cookie.AuthCookieProvider;
+import com.back.matchduo.global.security.jwt.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthService 단위 테스트")
+class AuthServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private JwtProperties jwtProperties;
+
+    @Mock
+    private AuthCookieProvider cookieProvider;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock(lenient = true)
+    private HttpServletResponse response;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .email("test@test.com")
+                .password("password123")
+                .nickname("테스터")
+                .verificationCode("VERIFIED")
+                .build();
+
+        // Reflection으로 ID 설정 (테스트용)
+        try {
+            var idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(testUser, 1L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("로그인 테스트")
+    class LoginTest {
+
+        @Test
+        @DisplayName("성공: 올바른 이메일과 비밀번호로 로그인")
+        void login_success() {
+            // given
+            LoginRequest request = new LoginRequest("test@test.com", "password123");
+
+            given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
+            given(jwtProvider.createAccessToken(1L)).willReturn("access-token");
+            given(jwtProvider.createRefreshToken(1L)).willReturn("refresh-token");
+            given(jwtProperties.accessExpireSeconds()).willReturn(3600L);
+            given(jwtProperties.refreshExpireSeconds()).willReturn(604800L);
+            given(cookieProvider.createAccessTokenCookie(any(), anyLong()))
+                    .willReturn(ResponseCookie.from("accessToken", "access-token").build());
+            given(cookieProvider.createRefreshTokenCookie(any(), anyLong()))
+                    .willReturn(ResponseCookie.from("refreshToken", "refresh-token").build());
+            given(refreshTokenRepository.findByUserId(1L)).willReturn(Optional.empty());
+            given(refreshTokenRepository.save(any())).willReturn(null);
+
+            // when
+            LoginResponse result = authService.login(request, response);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.user().userId()).isEqualTo(1L);
+            assertThat(result.user().email()).isEqualTo("test@test.com");
+            assertThat(result.user().nickname()).isEqualTo("테스터");
+            assertThat(result.accessToken()).isEqualTo("access-token");
+            assertThat(result.refreshToken()).isEqualTo("refresh-token");
+
+            verify(userRepository).findByEmail("test@test.com");
+            verify(jwtProvider).createAccessToken(1L);
+            verify(jwtProvider).createRefreshToken(1L);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 이메일")
+        void login_fail_email_not_found() {
+            // given
+            LoginRequest request = new LoginRequest("notexist@test.com", "password123");
+            given(userRepository.findByEmail("notexist@test.com")).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(request, response))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.NOT_FOUND_EMAIL);
+                    });
+
+            verify(userRepository).findByEmail("notexist@test.com");
+            verify(jwtProvider, never()).createAccessToken(anyLong());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 비밀번호")
+        void login_fail_wrong_password() {
+            // given
+            LoginRequest request = new LoginRequest("test@test.com", "wrongPassword");
+            given(userRepository.findByEmail("test@test.com")).willReturn(Optional.of(testUser));
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(request, response))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.WRONG_PASSWORD);
+                    });
+
+            verify(userRepository).findByEmail("test@test.com");
+            verify(jwtProvider, never()).createAccessToken(anyLong());
+        }
+
+        @Test
+        @DisplayName("성공: BCrypt 해시 비밀번호로 로그인")
+        void login_success_with_bcrypt_password() {
+            // given
+            String bcryptPassword = "$2a$10$abcdefghijklmnopqrstuvwxyz123456";
+            User bcryptUser = User.builder()
+                    .email("bcrypt@test.com")
+                    .password(bcryptPassword)
+                    .nickname("BCrypt유저")
+                    .verificationCode("VERIFIED")
+                    .build();
+
+            try {
+                var idField = User.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(bcryptUser, 2L);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            LoginRequest request = new LoginRequest("bcrypt@test.com", "password123");
+
+            given(userRepository.findByEmail("bcrypt@test.com")).willReturn(Optional.of(bcryptUser));
+            given(passwordEncoder.matches("password123", bcryptPassword)).willReturn(true);
+            given(jwtProvider.createAccessToken(2L)).willReturn("access-token");
+            given(jwtProvider.createRefreshToken(2L)).willReturn("refresh-token");
+            given(jwtProperties.accessExpireSeconds()).willReturn(3600L);
+            given(jwtProperties.refreshExpireSeconds()).willReturn(604800L);
+            given(cookieProvider.createAccessTokenCookie(any(), anyLong()))
+                    .willReturn(ResponseCookie.from("accessToken", "access-token").build());
+            given(cookieProvider.createRefreshTokenCookie(any(), anyLong()))
+                    .willReturn(ResponseCookie.from("refreshToken", "refresh-token").build());
+            given(refreshTokenRepository.findByUserId(2L)).willReturn(Optional.empty());
+            given(refreshTokenRepository.save(any())).willReturn(null);
+
+            // when
+            LoginResponse result = authService.login(request, response);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.user().userId()).isEqualTo(2L);
+            assertThat(result.user().email()).isEqualTo("bcrypt@test.com");
+
+            verify(passwordEncoder).matches("password123", bcryptPassword);
+            verify(jwtProvider).createAccessToken(2L);
+        }
+
+        @Test
+        @DisplayName("실패: BCrypt 해시 비밀번호 불일치")
+        void login_fail_bcrypt_password_mismatch() {
+            // given
+            String bcryptPassword = "$2a$10$abcdefghijklmnopqrstuvwxyz123456";
+            User bcryptUser = User.builder()
+                    .email("bcrypt@test.com")
+                    .password(bcryptPassword)
+                    .nickname("BCrypt유저")
+                    .verificationCode("VERIFIED")
+                    .build();
+
+            try {
+                var idField = User.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(bcryptUser, 2L);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            LoginRequest request = new LoginRequest("bcrypt@test.com", "wrongPassword");
+
+            given(userRepository.findByEmail("bcrypt@test.com")).willReturn(Optional.of(bcryptUser));
+            given(passwordEncoder.matches("wrongPassword", bcryptPassword)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.login(request, response))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.WRONG_PASSWORD);
+                    });
+
+            verify(passwordEncoder).matches("wrongPassword", bcryptPassword);
+            verify(jwtProvider, never()).createAccessToken(anyLong());
+        }
+
+        @Test
+        @DisplayName("성공: 레거시 평문 비밀번호 로그인 시 BCrypt로 마이그레이션")
+        void login_success_with_legacy_password_migration() {
+            // given
+            String plainPassword = "password123";
+            String encodedPassword = "$2a$10$newEncodedPassword";
+
+            User legacyUser = User.builder()
+                    .email("legacy@test.com")
+                    .password(plainPassword)
+                    .nickname("레거시유저")
+                    .verificationCode("VERIFIED")
+                    .build();
+
+            try {
+                var idField = User.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(legacyUser, 3L);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+
+            LoginRequest request = new LoginRequest("legacy@test.com", plainPassword);
+
+            given(userRepository.findByEmail("legacy@test.com")).willReturn(Optional.of(legacyUser));
+            given(passwordEncoder.encode(plainPassword)).willReturn(encodedPassword);
+            given(jwtProvider.createAccessToken(3L)).willReturn("access-token");
+            given(jwtProvider.createRefreshToken(3L)).willReturn("refresh-token");
+            given(jwtProperties.accessExpireSeconds()).willReturn(3600L);
+            given(jwtProperties.refreshExpireSeconds()).willReturn(604800L);
+            given(cookieProvider.createAccessTokenCookie(any(), anyLong()))
+                    .willReturn(ResponseCookie.from("accessToken", "access-token").build());
+            given(cookieProvider.createRefreshTokenCookie(any(), anyLong()))
+                    .willReturn(ResponseCookie.from("refreshToken", "refresh-token").build());
+            given(refreshTokenRepository.findByUserId(3L)).willReturn(Optional.empty());
+            given(refreshTokenRepository.save(any())).willReturn(null);
+
+            // when
+            LoginResponse result = authService.login(request, response);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.user().userId()).isEqualTo(3L);
+
+            // 평문 비밀번호가 BCrypt로 마이그레이션되었는지 확인
+            verify(passwordEncoder).encode(plainPassword);
+            assertThat(legacyUser.getPassword()).isEqualTo(encodedPassword);
+        }
+    }
+}


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #161 

## PR / 과제 설명 

1. 레거시 평문 비밀번호 사용자 로그인 실패 버그 수정 
2. BCrypt 해시 + 평문 비밀번호 호환 검증 로직 추가 
3. 인증 도메인 테스트 추가 

--- 

### ✔️ 버그 내용 

**현상**
- 기존 운영 서버에 가입된 유저가 로그인 시 실패하는 문제가 발생.
  신규 가입 유저는 정상적으로 로그인이 가능함

**원인**
- 비밀번호 인코딩(Bcrypt) 기능 도입 전 가입한 유저는 평문 비밀번호로 DB에 저장되어 있었음. 
- 비밀번호 인코딩 적용 후 로그인 시 Bcrypt 해시와 평문을 비교하게 되어 매칭에 실패.
  - 예시: DB 저장값 `password123` vs Bcrypt 비교 → 불일치

### ✔️ 영향 범위 
- 비밀번호 인코딩 적용 전 가입한 모든 유저  

---

### ✔️ 해결법 

`AuthService.validatePassword()` 메서드 추가 
> 저장된 비밀번호가 Bcrypt 해시인지 판별하여 `($2 로 시작 여부 확인)` 분기 처리함.

- **Bcrypt 해시인 경우**: `passwordEncoder.matches()`를 사용하여 검증 
- **평문인 경우**: 
  - 직접 문자열 비교 수행 후, 로그인 성공 시 Bcrypt로 인코딩하여 DB 자동 업데이트 
    (마이그레이션)

---

### ✔️ 변경 파일 

1️⃣ `AuthService.java`
- 레거시 평문 비밀번호와 Bcrypt 해시 비밀번호를 모두 처리할 수 있는 `validatePassword()` 
  메서드를 추가했음.
  - 평문 비밀번호로 로그인 성공 시 자동으로 Bcrypt로 마이그레이션됨
 
2️⃣ `application-test.yml`
- 테스트 환경 설정을 정리했음.
  - Mail, Riot API는 Mock 처리되어 실제 사용되지 않으므로 더미값으로 변경.
 
3️⃣ `AuthServiceTest.java` (신규)
- 로그인, 회원가입, 토큰 재발급, 로그아웃에 대한 단위 테스트 추가. 

4️⃣ `AuthServiceIntegrationTest.java` (신규)
- 레거시 평문 비밀번호 로그인 및 Bcrypt 자동 마이그레이션에 대한 통합 테스트를 추가.

5️⃣ `AuthControllerTest.java` (신규)
- 인증 관련 API 엔드포인트에 대한 컨트롤러 테스트를 추가. 
