### PR TITLE
[BE/feat] 도메인별 테스트 코드 추가

### DIFF
--- a/src/test/java/com/back/matchduo/domain/chat/service/ChatServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/chat/service/ChatServiceTest.java
@@ -6,6 +6,8 @@ import com.back.matchduo.domain.chat.entity.ChatMessage;
 import com.back.matchduo.domain.chat.entity.ChatMessageRead;
 import com.back.matchduo.domain.chat.entity.ChatRoom;
 import com.back.matchduo.domain.chat.entity.MessageType;
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.gameaccount.repository.GameAccountRepository;
 import com.back.matchduo.domain.post.entity.GameMode;
 import com.back.matchduo.domain.post.entity.Position;
 import com.back.matchduo.domain.post.entity.Post;
@@ -20,6 +22,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 class ChatServiceTest {
 
     @Autowired
@@ -41,8 +45,12 @@ class ChatServiceTest {
     @Autowired
     private PostRepository postRepository;
 
+    @Autowired
+    private GameAccountRepository gameAccountRepository;
+
     private User postAuthor;
     private User applicant;
+    private GameAccount testGameAccount;
     private Post testPost;
 
     @BeforeEach
@@ -61,10 +69,19 @@ class ChatServiceTest {
                 .verificationCode("5678")
                 .build());
 
+        testGameAccount = gameAccountRepository.save(GameAccount.builder()
+                .gameNickname("채팅테스트게이머")
+                .gameTag("KR1")
+                .gameType("LOL")
+                .puuid("chat-test-puuid-12345")
+                .profileIconId(1234)
+                .user(postAuthor)
+                .build());
 
         testPost = postRepository.save(Post.builder()
                 .user(postAuthor)
-                .gameMode(GameMode.SUMMONERS_RIFT) // [변경] Enum 상수명에 맞게 수정 (예: SUMMONERS_RIFT)
+                .gameAccount(testGameAccount)
+                .gameMode(GameMode.SUMMONERS_RIFT)
                 .queueType(QueueType.DUO)
                 .myPosition(Position.MID)
                 .lookingPositions("[\"TOP\", \"JUNGLE\"]")

--- a/src/test/java/com/back/matchduo/domain/chat/service/ChatUnreadCacheServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/chat/service/ChatUnreadCacheServiceTest.java
@@ -1,0 +1,248 @@
+package com.back.matchduo.domain.chat.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChatUnreadCacheService 테스트")
+class ChatUnreadCacheServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Long> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Long> valueOperations;
+
+    @InjectMocks
+    private ChatUnreadCacheService chatUnreadCacheService;
+
+    private static final Long CHAT_ROOM_ID = 1L;
+    private static final Long USER_ID = 100L;
+    private static final String EXPECTED_KEY = "chat:unread:1:100";
+
+    @Nested
+    @DisplayName("increment 메서드")
+    class IncrementTest {
+
+        @BeforeEach
+        void setUp() {
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        }
+
+        @Test
+        @DisplayName("unread 카운트 증가 성공")
+        void increment_success() {
+            // given
+            given(valueOperations.increment(EXPECTED_KEY)).willReturn(1L);
+            given(redisTemplate.expire(eq(EXPECTED_KEY), any(Duration.class))).willReturn(true);
+
+            // when
+            chatUnreadCacheService.increment(CHAT_ROOM_ID, USER_ID);
+
+            // then
+            verify(valueOperations).increment(EXPECTED_KEY);
+            verify(redisTemplate).expire(eq(EXPECTED_KEY), any(Duration.class));
+        }
+
+        @Test
+        @DisplayName("Redis 연결 실패 시 예외를 삼키고 정상 종료")
+        void increment_fail_gracefully() {
+            // given
+            given(valueOperations.increment(anyString())).willThrow(new RuntimeException("Redis 연결 실패"));
+
+            // when - 예외가 발생하지 않아야 함
+            chatUnreadCacheService.increment(CHAT_ROOM_ID, USER_ID);
+
+            // then - 예외 없이 정상 종료 확인
+            verify(valueOperations).increment(EXPECTED_KEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("reset 메서드")
+    class ResetTest {
+
+        @BeforeEach
+        void setUp() {
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        }
+
+        @Test
+        @DisplayName("unread 카운트 초기화 성공")
+        void reset_success() {
+            // when
+            chatUnreadCacheService.reset(CHAT_ROOM_ID, USER_ID);
+
+            // then
+            verify(valueOperations).set(eq(EXPECTED_KEY), eq(0L), any(Duration.class));
+        }
+
+        @Test
+        @DisplayName("Redis 연결 실패 시 예외를 삼키고 정상 종료")
+        void reset_fail_gracefully() {
+            // given
+            org.mockito.Mockito.doThrow(new RuntimeException("Redis 연결 실패"))
+                    .when(valueOperations).set(anyString(), anyLong(), any(Duration.class));
+
+            // when - 예외가 발생하지 않아야 함
+            chatUnreadCacheService.reset(CHAT_ROOM_ID, USER_ID);
+
+            // then - 예외 없이 정상 종료 확인
+            verify(valueOperations).set(eq(EXPECTED_KEY), eq(0L), any(Duration.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrSync 메서드")
+    class GetOrSyncTest {
+
+        @BeforeEach
+        void setUp() {
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        }
+
+        @Test
+        @DisplayName("Redis에 캐시가 있으면 캐시값 반환")
+        void getOrSync_cache_hit() {
+            // given
+            given(valueOperations.get(EXPECTED_KEY)).willReturn(5L);
+
+            // when
+            int result = chatUnreadCacheService.getOrSync(CHAT_ROOM_ID, USER_ID, () -> 10L);
+
+            // then
+            assertThat(result).isEqualTo(5);
+            verify(valueOperations).get(EXPECTED_KEY);
+            verify(valueOperations, never()).set(anyString(), anyLong(), any(Duration.class));
+        }
+
+        @Test
+        @DisplayName("Redis에 캐시가 없으면 DB fallback 후 캐시 저장")
+        void getOrSync_cache_miss() {
+            // given
+            given(valueOperations.get(EXPECTED_KEY)).willReturn(null);
+
+            // when
+            int result = chatUnreadCacheService.getOrSync(CHAT_ROOM_ID, USER_ID, () -> 3L);
+
+            // then
+            assertThat(result).isEqualTo(3);
+            verify(valueOperations).get(EXPECTED_KEY);
+            verify(valueOperations).set(eq(EXPECTED_KEY), eq(3L), any(Duration.class));
+        }
+
+        @Test
+        @DisplayName("Redis 연결 실패 시 DB fallback 값 반환")
+        void getOrSync_fail_fallback() {
+            // given
+            given(valueOperations.get(anyString())).willThrow(new RuntimeException("Redis 연결 실패"));
+
+            // when
+            int result = chatUnreadCacheService.getOrSync(CHAT_ROOM_ID, USER_ID, () -> 7L);
+
+            // then
+            assertThat(result).isEqualTo(7);
+        }
+    }
+
+    @Nested
+    @DisplayName("delete 메서드")
+    class DeleteTest {
+
+        @Test
+        @DisplayName("키 삭제 성공")
+        void delete_success() {
+            // given
+            given(redisTemplate.delete(EXPECTED_KEY)).willReturn(true);
+
+            // when
+            chatUnreadCacheService.delete(CHAT_ROOM_ID, USER_ID);
+
+            // then
+            verify(redisTemplate).delete(EXPECTED_KEY);
+        }
+
+        @Test
+        @DisplayName("Redis 연결 실패 시 예외를 삼키고 정상 종료")
+        void delete_fail_gracefully() {
+            // given
+            given(redisTemplate.delete(anyString())).willThrow(new RuntimeException("Redis 연결 실패"));
+
+            // when
+            chatUnreadCacheService.delete(CHAT_ROOM_ID, USER_ID);
+
+            // then
+            verify(redisTemplate).delete(EXPECTED_KEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("deleteByChatRoomId 메서드")
+    class DeleteByChatRoomIdTest {
+
+        @Test
+        @DisplayName("채팅방 관련 모든 키 삭제 성공")
+        void deleteByChatRoomId_success() {
+            // given
+            String pattern = "chat:unread:1:*";
+            Set<String> keys = Set.of("chat:unread:1:100", "chat:unread:1:200");
+            given(redisTemplate.keys(pattern)).willReturn(keys);
+            given(redisTemplate.delete(keys)).willReturn(2L);
+
+            // when
+            chatUnreadCacheService.deleteByChatRoomId(CHAT_ROOM_ID);
+
+            // then
+            verify(redisTemplate).keys(pattern);
+            verify(redisTemplate).delete(keys);
+        }
+
+        @Test
+        @DisplayName("삭제할 키가 없으면 delete 호출 안함")
+        void deleteByChatRoomId_no_keys() {
+            // given
+            String pattern = "chat:unread:1:*";
+            given(redisTemplate.keys(pattern)).willReturn(Set.of());
+
+            // when
+            chatUnreadCacheService.deleteByChatRoomId(CHAT_ROOM_ID);
+
+            // then
+            verify(redisTemplate).keys(pattern);
+            verify(redisTemplate, never()).delete(any(Set.class));
+        }
+
+        @Test
+        @DisplayName("Redis 연결 실패 시 예외를 삼키고 정상 종료")
+        void deleteByChatRoomId_fail_gracefully() {
+            // given
+            given(redisTemplate.keys(anyString())).willThrow(new RuntimeException("Redis 연결 실패"));
+
+            // when
+            chatUnreadCacheService.deleteByChatRoomId(CHAT_ROOM_ID);
+
+            // then
+            verify(redisTemplate).keys("chat:unread:1:*");
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/gameaccount/service/GameAccountServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/gameaccount/service/GameAccountServiceTest.java
@@ -1,0 +1,335 @@
+package com.back.matchduo.domain.gameaccount.service;
+
+import com.back.matchduo.domain.gameaccount.client.RiotApiClient;
+import com.back.matchduo.domain.gameaccount.dto.RiotApiDto;
+import com.back.matchduo.domain.gameaccount.dto.request.GameAccountCreateRequest;
+import com.back.matchduo.domain.gameaccount.dto.request.GameAccountUpdateRequest;
+import com.back.matchduo.domain.gameaccount.dto.response.GameAccountResponse;
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.gameaccount.repository.GameAccountRepository;
+import com.back.matchduo.domain.gameaccount.repository.RankRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GameAccountService 테스트")
+class GameAccountServiceTest {
+
+    @Mock
+    private GameAccountRepository gameAccountRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RiotApiClient riotApiClient;
+
+    @Mock
+    private RankRepository rankRepository;
+
+    @Mock
+    private DataDragonService dataDragonService;
+
+    @Mock
+    private RankService rankService;
+
+    @Mock
+    private MatchService matchService;
+
+    private GameAccountService gameAccountService;
+
+    private User testUser;
+    private GameAccount testGameAccount;
+
+    private static final Long USER_ID = 1L;
+    private static final Long GAME_ACCOUNT_ID = 100L;
+    private static final String GAME_TYPE = "LEAGUE_OF_LEGENDS";
+    private static final String GAME_NICKNAME = "TestPlayer";
+    private static final String GAME_TAG = "KR1";
+    private static final String PUUID = "test-puuid-12345";
+
+    @BeforeEach
+    void setUp() {
+        gameAccountService = new GameAccountService(
+                gameAccountRepository,
+                userRepository,
+                riotApiClient,
+                rankRepository,
+                dataDragonService,
+                rankService,
+                matchService
+        );
+
+        testUser = User.builder()
+                .id(USER_ID)
+                .email("test@example.com")
+                .password("password123")
+                .nickname("테스터")
+                .verificationCode("VERIFIED")
+                .build();
+
+        testGameAccount = GameAccount.builder()
+                .gameNickname(GAME_NICKNAME)
+                .gameTag(GAME_TAG)
+                .gameType(GAME_TYPE)
+                .puuid(PUUID)
+                .profileIconId(1234)
+                .user(testUser)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("게임 계정 생성")
+    class CreateGameAccountTest {
+
+        @Test
+        @DisplayName("성공: 게임 계정 생성")
+        void createGameAccount_success() {
+            // given
+            GameAccountCreateRequest request = GameAccountCreateRequest.builder()
+                    .gameType(GAME_TYPE)
+                    .gameNickname(GAME_NICKNAME)
+                    .gameTag(GAME_TAG)
+                    .build();
+
+            RiotApiDto.AccountResponse accountResponse = RiotApiDto.AccountResponse.builder()
+                    .puuid(PUUID)
+                    .gameName(GAME_NICKNAME)
+                    .tagLine(GAME_TAG)
+                    .build();
+
+            RiotApiDto.SummonerResponse summonerResponse = RiotApiDto.SummonerResponse.builder()
+                    .profileIconId(1234)
+                    .build();
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(testUser));
+            given(gameAccountRepository.findByUser_IdAndGameType(USER_ID, GAME_TYPE)).willReturn(Optional.empty());
+            given(riotApiClient.getAccountByRiotId(GAME_NICKNAME, GAME_TAG)).willReturn(accountResponse);
+            given(riotApiClient.getSummonerByPuuid(PUUID)).willReturn(summonerResponse);
+            given(dataDragonService.getLatestVersion()).willReturn("14.1.1");
+            given(gameAccountRepository.save(any(GameAccount.class))).willAnswer(invocation -> {
+                GameAccount ga = invocation.getArgument(0);
+                return GameAccount.builder()
+                        .gameNickname(ga.getGameNickname())
+                        .gameTag(ga.getGameTag())
+                        .gameType(ga.getGameType())
+                        .puuid(ga.getPuuid())
+                        .profileIconId(ga.getProfileIconId())
+                        .user(ga.getUser())
+                        .build();
+            });
+
+            // when
+            GameAccountResponse response = gameAccountService.createGameAccount(request, USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getGameNickname()).isEqualTo(GAME_NICKNAME);
+            assertThat(response.getGameTag()).isEqualTo(GAME_TAG);
+            verify(gameAccountRepository).save(any(GameAccount.class));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자")
+        void createGameAccount_fail_userNotFound() {
+            // given
+            GameAccountCreateRequest request = GameAccountCreateRequest.builder()
+                    .gameType(GAME_TYPE)
+                    .gameNickname(GAME_NICKNAME)
+                    .gameTag(GAME_TAG)
+                    .build();
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> gameAccountService.createGameAccount(request, USER_ID))
+                    .isInstanceOf(CustomException.class);
+
+            verify(gameAccountRepository, never()).save(any(GameAccount.class));
+        }
+
+        @Test
+        @DisplayName("실패: 중복된 게임 계정")
+        void createGameAccount_fail_duplicateAccount() {
+            // given
+            GameAccountCreateRequest request = GameAccountCreateRequest.builder()
+                    .gameType(GAME_TYPE)
+                    .gameNickname(GAME_NICKNAME)
+                    .gameTag(GAME_TAG)
+                    .build();
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(testUser));
+            given(gameAccountRepository.findByUser_IdAndGameType(USER_ID, GAME_TYPE))
+                    .willReturn(Optional.of(testGameAccount));
+
+            // when & then
+            assertThatThrownBy(() -> gameAccountService.createGameAccount(request, USER_ID))
+                    .isInstanceOf(CustomException.class);
+
+            verify(gameAccountRepository, never()).save(any(GameAccount.class));
+        }
+
+        @Test
+        @DisplayName("성공: Riot API 실패 시에도 계정 생성 (puuid null)")
+        void createGameAccount_success_riotApiFail() {
+            // given
+            GameAccountCreateRequest request = GameAccountCreateRequest.builder()
+                    .gameType(GAME_TYPE)
+                    .gameNickname(GAME_NICKNAME)
+                    .gameTag(GAME_TAG)
+                    .build();
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(testUser));
+            given(gameAccountRepository.findByUser_IdAndGameType(USER_ID, GAME_TYPE)).willReturn(Optional.empty());
+            given(riotApiClient.getAccountByRiotId(GAME_NICKNAME, GAME_TAG))
+                    .willThrow(new RuntimeException("Network error"));
+            given(gameAccountRepository.save(any(GameAccount.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            GameAccountResponse response = gameAccountService.createGameAccount(request, USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getPuuid()).isNull();
+            verify(gameAccountRepository).save(any(GameAccount.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("게임 계정 조회")
+    class GetGameAccountTest {
+
+        @BeforeEach
+        void setUp() {
+            lenient().when(dataDragonService.getLatestVersion()).thenReturn("14.1.1");
+        }
+
+        @Test
+        @DisplayName("성공: 게임 계정 조회")
+        void getGameAccount_success() {
+            // given
+            given(gameAccountRepository.findById(GAME_ACCOUNT_ID)).willReturn(Optional.of(testGameAccount));
+
+            // when
+            GameAccountResponse response = gameAccountService.getGameAccount(GAME_ACCOUNT_ID, USER_ID);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.getGameNickname()).isEqualTo(GAME_NICKNAME);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 게임 계정")
+        void getGameAccount_fail_notFound() {
+            // given
+            given(gameAccountRepository.findById(GAME_ACCOUNT_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> gameAccountService.getGameAccount(GAME_ACCOUNT_ID, USER_ID))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 게임 계정 목록 조회")
+    class GetUserGameAccountsTest {
+
+        @BeforeEach
+        void setUp() {
+            lenient().when(dataDragonService.getLatestVersion()).thenReturn("14.1.1");
+        }
+
+        @Test
+        @DisplayName("성공: 사용자 게임 계정 조회")
+        void getUserGameAccounts_success() {
+            // given
+            given(gameAccountRepository.findByUser_Id(USER_ID)).willReturn(Optional.of(testGameAccount));
+
+            // when
+            List<GameAccountResponse> responses = gameAccountService.getUserGameAccounts(USER_ID);
+
+            // then
+            assertThat(responses).hasSize(1);
+            assertThat(responses.get(0).getGameNickname()).isEqualTo(GAME_NICKNAME);
+        }
+
+        @Test
+        @DisplayName("성공: 게임 계정이 없는 경우 빈 리스트 반환")
+        void getUserGameAccounts_success_emptyList() {
+            // given
+            given(gameAccountRepository.findByUser_Id(USER_ID)).willReturn(Optional.empty());
+
+            // when
+            List<GameAccountResponse> responses = gameAccountService.getUserGameAccounts(USER_ID);
+
+            // then
+            assertThat(responses).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("게임 계정 삭제")
+    class DeleteGameAccountTest {
+
+        @Test
+        @DisplayName("성공: 게임 계정 삭제")
+        void deleteGameAccount_success() {
+            // given
+            given(gameAccountRepository.findById(GAME_ACCOUNT_ID)).willReturn(Optional.of(testGameAccount));
+            given(rankRepository.findByGameAccount_GameAccountId(GAME_ACCOUNT_ID)).willReturn(List.of());
+
+            // when
+            gameAccountService.deleteGameAccount(GAME_ACCOUNT_ID, USER_ID);
+
+            // then
+            verify(matchService).deleteMatchesByGameAccountId(GAME_ACCOUNT_ID);
+            verify(gameAccountRepository).delete(testGameAccount);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 게임 계정")
+        void deleteGameAccount_fail_notFound() {
+            // given
+            given(gameAccountRepository.findById(GAME_ACCOUNT_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> gameAccountService.deleteGameAccount(GAME_ACCOUNT_ID, USER_ID))
+                    .isInstanceOf(CustomException.class);
+
+            verify(gameAccountRepository, never()).delete(any(GameAccount.class));
+        }
+
+        @Test
+        @DisplayName("실패: 권한 없는 사용자")
+        void deleteGameAccount_fail_forbidden() {
+            // given
+            Long otherUserId = 999L;
+            given(gameAccountRepository.findById(GAME_ACCOUNT_ID)).willReturn(Optional.of(testGameAccount));
+
+            // when & then
+            assertThatThrownBy(() -> gameAccountService.deleteGameAccount(GAME_ACCOUNT_ID, otherUserId))
+                    .isInstanceOf(CustomException.class);
+
+            verify(gameAccountRepository, never()).delete(any(GameAccount.class));
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/gameaccount/service/GameAccountServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/gameaccount/service/GameAccountServiceTest.java
@@ -10,6 +10,7 @@ import com.back.matchduo.domain.gameaccount.repository.GameAccountRepository;
 import com.back.matchduo.domain.gameaccount.repository.RankRepository;
 import com.back.matchduo.domain.user.entity.User;
 import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.domain.post.repository.PostRepository;
 import com.back.matchduo.global.exeption.CustomException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -55,6 +56,9 @@ class GameAccountServiceTest {
     @Mock
     private MatchService matchService;
 
+    @Mock
+    private PostRepository postRepository;
+
     private GameAccountService gameAccountService;
 
     private User testUser;
@@ -76,7 +80,8 @@ class GameAccountServiceTest {
                 rankRepository,
                 dataDragonService,
                 rankService,
-                matchService
+                matchService,
+                postRepository
         );
 
         testUser = User.builder()

--- a/src/test/java/com/back/matchduo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/party/service/PartyServiceTest.java
@@ -1,0 +1,356 @@
+package com.back.matchduo.domain.party.service;
+
+import com.back.matchduo.domain.chat.repository.ChatRoomRepository;
+import com.back.matchduo.domain.party.dto.request.PartyMemberAddRequest;
+import com.back.matchduo.domain.party.dto.response.PartyByPostResponse;
+import com.back.matchduo.domain.party.dto.response.PartyCloseResponse;
+import com.back.matchduo.domain.party.dto.response.PartyMemberAddResponse;
+import com.back.matchduo.domain.party.dto.response.PartyMemberRemoveResponse;
+import com.back.matchduo.domain.party.entity.*;
+import com.back.matchduo.domain.party.repository.PartyMemberRepository;
+import com.back.matchduo.domain.party.repository.PartyRepository;
+import com.back.matchduo.domain.post.entity.GameMode;
+import com.back.matchduo.domain.post.entity.Position;
+import com.back.matchduo.domain.post.entity.Post;
+import com.back.matchduo.domain.post.entity.QueueType;
+import com.back.matchduo.domain.post.repository.PostRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PartyService 단위 테스트")
+class PartyServiceTest {
+
+    @Mock
+    private PartyRepository partyRepository;
+
+    @Mock
+    private PartyMemberRepository partyMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @InjectMocks
+    private PartyService partyService;
+
+    private User leaderUser;
+    private User memberUser;
+    private User targetUser;
+    private Party party;
+    private Post post;
+    private PartyMember leaderMember;
+    private PartyMember normalMember;
+
+    @BeforeEach
+    void setUp() {
+        leaderUser = createUserWithId(1L, "leader@test.com", "파티장");
+        memberUser = createUserWithId(2L, "member@test.com", "파티원");
+        targetUser = createUserWithId(3L, "target@test.com", "초대대상");
+
+        party = createPartyWithId(1L, 100L, 1L);
+        post = createPostWithId(100L, leaderUser, 2);
+
+        leaderMember = createPartyMember(1L, party, leaderUser, PartyMemberRole.LEADER);
+        normalMember = createPartyMember(2L, party, memberUser, PartyMemberRole.MEMBER);
+    }
+
+    private User createUserWithId(Long id, String email, String nickname) {
+        User user = User.builder()
+                .email(email)
+                .password("password123")
+                .nickname(nickname)
+                .verificationCode("VERIFIED")
+                .build();
+        setId(user, id, User.class);
+        return user;
+    }
+
+    private Party createPartyWithId(Long id, Long postId, Long leaderId) {
+        Party party = new Party(postId, leaderId);
+        setId(party, id, Party.class);
+        return party;
+    }
+
+    private Post createPostWithId(Long id, User user, int recruitCount) {
+        Post post = Post.builder()
+                .user(user)
+                .gameMode(GameMode.SUMMONERS_RIFT)
+                .queueType(QueueType.DUO)
+                .myPosition(Position.TOP)
+                .lookingPositions("[\"JUNGLE\"]")
+                .mic(true)
+                .recruitCount(recruitCount)
+                .memo("테스트 모집글")
+                .build();
+        setId(post, id, Post.class);
+        return post;
+    }
+
+    private PartyMember createPartyMember(Long id, Party party, User user, PartyMemberRole role) {
+        PartyMember member = new PartyMember(party, user, role);
+        setId(member, id, PartyMember.class);
+        return member;
+    }
+
+    private void setId(Object entity, Long id, Class<?> clazz) {
+        try {
+            var idField = clazz.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("파티 조회 테스트")
+    class GetPartyTest {
+
+        @Test
+        @DisplayName("성공: 모집글 기준 파티 조회 - 로그인 유저")
+        void getPartyByPostId_success_loggedIn() {
+            // given
+            given(partyRepository.findByPostId(100L)).willReturn(Optional.of(party));
+            given(partyMemberRepository.findByPartyId(1L)).willReturn(List.of(leaderMember, normalMember));
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+
+            // when
+            PartyByPostResponse result = partyService.getPartyByPostId(100L, 1L);
+
+            // then
+            assertThat(result.postId()).isEqualTo(100L);
+            assertThat(result.status()).isEqualTo(PartyStatus.RECRUIT);
+            assertThat(result.isJoined()).isTrue();
+            assertThat(result.members()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("성공: 모집글 기준 파티 조회 - 비로그인")
+        void getPartyByPostId_success_guest() {
+            // given
+            given(partyRepository.findByPostId(100L)).willReturn(Optional.of(party));
+            given(partyMemberRepository.findByPartyId(1L)).willReturn(List.of(leaderMember, normalMember));
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+
+            // when
+            PartyByPostResponse result = partyService.getPartyByPostId(100L, null);
+
+            // then
+            assertThat(result.isJoined()).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 파티")
+        void getPartyByPostId_fail_not_found() {
+            // given
+            given(partyRepository.findByPostId(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> partyService.getPartyByPostId(999L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.PARTY_NOT_FOUND);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("파티원 추가 테스트")
+    class AddMembersTest {
+
+        @Test
+        @DisplayName("성공: 파티장이 유저를 초대")
+        void addMembers_success() {
+            // given
+            PartyMemberAddRequest request = new PartyMemberAddRequest(List.of(3L));
+
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+            given(partyMemberRepository.findByPartyIdAndUserId(1L, 3L)).willReturn(Optional.empty());
+            given(userRepository.findById(3L)).willReturn(Optional.of(targetUser));
+            given(partyMemberRepository.save(any(PartyMember.class))).willAnswer(invocation -> {
+                PartyMember member = invocation.getArgument(0);
+                setId(member, 3L, PartyMember.class);
+                return member;
+            });
+            given(partyMemberRepository.countByPartyIdAndState(1L, PartyMemberState.JOINED)).willReturn(2);
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+
+            // when
+            List<PartyMemberAddResponse> result = partyService.addMembers(1L, 1L, request);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).userId()).isEqualTo(3L);
+            verify(partyMemberRepository).save(any(PartyMember.class));
+        }
+
+        @Test
+        @DisplayName("실패: 파티장이 아닌 유저가 초대 시도")
+        void addMembers_fail_not_leader() {
+            // given
+            PartyMemberAddRequest request = new PartyMemberAddRequest(List.of(3L));
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+
+            // when & then
+            assertThatThrownBy(() -> partyService.addMembers(1L, 2L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.NOT_PARTY_LEADER);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 종료된 파티에 멤버 추가 시도")
+        void addMembers_fail_party_closed() {
+            // given
+            party.closeParty();
+            PartyMemberAddRequest request = new PartyMemberAddRequest(List.of(3L));
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+
+            // when & then
+            assertThatThrownBy(() -> partyService.addMembers(1L, 1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.PARTY_ALREADY_CLOSED);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("파티원 강퇴 테스트")
+    class RemoveMemberTest {
+
+        @Test
+        @DisplayName("성공: 파티장이 멤버 강퇴")
+        void removeMember_success() {
+            // given
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+            given(partyMemberRepository.findById(2L)).willReturn(Optional.of(normalMember));
+
+            // when
+            PartyMemberRemoveResponse result = partyService.removeMember(1L, 2L, 1L);
+
+            // then
+            assertThat(result.partyMemberId()).isEqualTo(2L);
+            // leaveParty() 호출 후 상태가 LEFT로 변경됨
+            assertThat(normalMember.getState()).isEqualTo(PartyMemberState.LEFT);
+        }
+
+        @Test
+        @DisplayName("실패: 파티장이 아닌 유저가 강퇴 시도")
+        void removeMember_fail_not_leader() {
+            // given
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+
+            // when & then
+            assertThatThrownBy(() -> partyService.removeMember(1L, 2L, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.NOT_PARTY_LEADER);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 파티장이 자기 자신 강퇴 시도")
+        void removeMember_fail_kick_self() {
+            // given
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+            given(partyMemberRepository.findById(1L)).willReturn(Optional.of(leaderMember));
+
+            // when & then
+            assertThatThrownBy(() -> partyService.removeMember(1L, 1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.CANNOT_KICK_LEADER);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("파티 종료 테스트")
+    class ClosePartyTest {
+
+        @Test
+        @DisplayName("성공: 파티장이 파티 종료")
+        void closeParty_success() {
+            // given
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+
+            // when
+            PartyCloseResponse result = partyService.closeParty(1L, 1L);
+
+            // then
+            assertThat(result.partyId()).isEqualTo(1L);
+            assertThat(result.status()).isEqualTo("CLOSED");
+            assertThat(result.closedAt()).isNotNull();
+            verify(eventPublisher).publishEvent(any(Object.class));
+        }
+
+        @Test
+        @DisplayName("실패: 파티장이 아닌 유저가 종료 시도")
+        void closeParty_fail_not_leader() {
+            // given
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+
+            // when & then
+            assertThatThrownBy(() -> partyService.closeParty(1L, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.NOT_PARTY_LEADER);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 이미 종료된 파티 재종료 시도")
+        void closeParty_fail_already_closed() {
+            // given
+            party.closeParty();
+            given(partyRepository.findById(1L)).willReturn(Optional.of(party));
+
+            // when & then
+            assertThatThrownBy(() -> partyService.closeParty(1L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.PARTY_ALREADY_CLOSED);
+                    });
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/back/matchduo/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,311 @@
+package com.back.matchduo.domain.post.controller;
+
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.gameaccount.repository.GameAccountRepository;
+import com.back.matchduo.domain.party.entity.Party;
+import com.back.matchduo.domain.party.entity.PartyMember;
+import com.back.matchduo.domain.party.entity.PartyMemberRole;
+import com.back.matchduo.domain.party.repository.PartyMemberRepository;
+import com.back.matchduo.domain.party.repository.PartyRepository;
+import com.back.matchduo.domain.post.entity.GameMode;
+import com.back.matchduo.domain.post.entity.Position;
+import com.back.matchduo.domain.post.entity.Post;
+import com.back.matchduo.domain.post.entity.PostStatus;
+import com.back.matchduo.domain.post.entity.QueueType;
+import com.back.matchduo.domain.post.repository.PostRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.security.CustomUserDetails;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Post API 통합 테스트")
+class PostControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PartyRepository partyRepository;
+
+    @Autowired
+    private PartyMemberRepository partyMemberRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameAccountRepository gameAccountRepository;
+
+    private User testUser;
+    private User testUser2;
+    private GameAccount testGameAccount;
+    private Post recruitPost;
+    private Post activePost;
+    private Post closedPost;
+
+    @BeforeAll
+    void setUp() {
+        // 테스트 유저 생성
+        testUser = User.builder()
+                .email("posttest@test.com")
+                .password("password123")
+                .nickname("포스트테스터")
+                .verificationCode("VERIFIED")
+                .build();
+        userRepository.save(testUser);
+
+        testUser2 = User.builder()
+                .email("posttest2@test.com")
+                .password("password123")
+                .nickname("포스트테스터2")
+                .verificationCode("VERIFIED")
+                .build();
+        userRepository.save(testUser2);
+
+        // 테스트 게임 계정 생성
+        testGameAccount = GameAccount.builder()
+                .gameNickname("테스트게이머")
+                .gameTag("KR1")
+                .gameType("LOL")
+                .puuid("test-puuid-12345")
+                .profileIconId(1234)
+                .user(testUser)
+                .build();
+        gameAccountRepository.save(testGameAccount);
+
+        // RECRUIT 상태 모집글
+        recruitPost = Post.builder()
+                .user(testUser)
+                .gameAccount(testGameAccount)
+                .gameMode(GameMode.SUMMONERS_RIFT)
+                .queueType(QueueType.DUO)
+                .myPosition(Position.TOP)
+                .lookingPositions("[\"JUNGLE\"]")
+                .mic(true)
+                .recruitCount(2)
+                .memo("모집중 테스트")
+                .build();
+        postRepository.save(recruitPost);
+
+        // RECRUIT 파티 생성
+        Party recruitParty = new Party(recruitPost.getId(), testUser.getId());
+        partyRepository.save(recruitParty);
+        partyMemberRepository.save(new PartyMember(recruitParty, testUser, PartyMemberRole.LEADER));
+
+        // ACTIVE 상태 모집글 (모집 완료)
+        activePost = Post.builder()
+                .user(testUser)
+                .gameAccount(testGameAccount)
+                .gameMode(GameMode.SUMMONERS_RIFT)
+                .queueType(QueueType.FLEX)
+                .myPosition(Position.MID)
+                .lookingPositions("[\"SUPPORT\"]")
+                .mic(false)
+                .recruitCount(2)
+                .memo("모집완료 테스트")
+                .build();
+        postRepository.save(activePost);
+        activePost.updateStatus(PostStatus.ACTIVE);
+        postRepository.save(activePost);
+
+        // ACTIVE 파티 생성
+        Party activeParty = new Party(activePost.getId(), testUser.getId());
+        activeParty.activateParty(java.time.LocalDateTime.now().plusHours(6));
+        partyRepository.save(activeParty);
+        partyMemberRepository.save(new PartyMember(activeParty, testUser, PartyMemberRole.LEADER));
+        partyMemberRepository.save(new PartyMember(activeParty, testUser2, PartyMemberRole.MEMBER));
+
+        // CLOSED 상태 모집글
+        closedPost = Post.builder()
+                .user(testUser)
+                .gameAccount(testGameAccount)
+                .gameMode(GameMode.HOWLING_ABYSS)
+                .queueType(QueueType.NORMAL)
+                .myPosition(Position.ANY)
+                .lookingPositions("[\"ANY\"]")
+                .mic(false)
+                .recruitCount(5)
+                .memo("종료된 테스트")
+                .build();
+        postRepository.save(closedPost);
+        closedPost.updateStatus(PostStatus.CLOSED);
+        postRepository.save(closedPost);
+
+        // CLOSED 파티 생성
+        Party closedParty = new Party(closedPost.getId(), testUser.getId());
+        closedParty.closeParty();
+        partyRepository.save(closedParty);
+    }
+
+    @Nested
+    @DisplayName("모집글 상태별 조회 테스트")
+    class GetPostsByStatus {
+
+        @Test
+        @DisplayName("성공: status=RECRUIT로 조회하면 모집중인 글만 반환된다")
+        void success_filter_recruit() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts")
+                            .param("status", "RECRUIT")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.posts").isArray())
+                    .andExpect(jsonPath("$.posts[?(@.status == 'RECRUIT')]").exists())
+                    .andExpect(jsonPath("$.posts[?(@.status == 'ACTIVE')]").doesNotExist())
+                    .andExpect(jsonPath("$.posts[?(@.status == 'CLOSED')]").doesNotExist())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: status=ACTIVE로 조회하면 모집완료된 글만 반환된다")
+        void success_filter_active() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts")
+                            .param("status", "ACTIVE")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.posts").isArray())
+                    .andExpect(jsonPath("$.posts[?(@.status == 'ACTIVE')]").exists())
+                    .andExpect(jsonPath("$.posts[?(@.status == 'RECRUIT')]").doesNotExist())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: status 파라미터 없이 조회하면 CLOSED 제외한 모든 글 반환")
+        void success_filter_all_except_closed() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.posts").isArray())
+                    .andExpect(jsonPath("$.posts[?(@.status == 'CLOSED')]").doesNotExist())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: status=RECRUIT + queueType=FLEX 복합 필터링")
+        void success_filter_combined() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts")
+                            .param("status", "RECRUIT")
+                            .param("queueType", "FLEX")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.posts").isArray())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: 비로그인 상태에서도 목록 조회 가능")
+        void success_guest_access() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.posts").isArray())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: 로그인 상태에서 목록 조회")
+        void success_authenticated_access() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(testUser)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.posts").isArray())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("모집글 단건 조회 테스트")
+    class GetPostDetail {
+
+        @Test
+        @DisplayName("성공: 모집글 상세 조회")
+        void success_get_detail() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts/{postId}", recruitPost.getId())
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(testUser)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.postId").value(recruitPost.getId()))
+                    .andExpect(jsonPath("$.memo").value("모집중 테스트"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 모집글 조회")
+        void fail_post_not_found() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/posts/{postId}", 99999L)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(testUser)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isNotFound())
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/post/service/PostServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/post/service/PostServiceTest.java
@@ -1,0 +1,402 @@
+package com.back.matchduo.domain.post.service;
+
+import com.back.matchduo.domain.party.entity.Party;
+import com.back.matchduo.domain.party.repository.PartyRepository;
+import com.back.matchduo.domain.post.dto.request.PostStatusUpdateRequest;
+import com.back.matchduo.domain.post.dto.request.PostUpdateRequest;
+import com.back.matchduo.domain.post.dto.response.PostDeleteResponse;
+import com.back.matchduo.domain.post.dto.response.PostStatusUpdateResponse;
+import com.back.matchduo.domain.post.dto.response.PostUpdateResponse;
+import com.back.matchduo.domain.post.entity.*;
+import com.back.matchduo.domain.post.repository.PostRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PostService 단위 테스트")
+class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private PartyRepository partyRepository;
+
+    @Mock
+    private PostValidator postValidator;
+
+    @Mock
+    private PostListFacade postListFacade;
+
+    @InjectMocks
+    private PostService postService;
+
+    private User user;
+    private User otherUser;
+    private Post post;
+    private Party party;
+
+    @BeforeEach
+    void setUp() {
+        user = createUserWithId(1L, "test@test.com", "테스트유저");
+        otherUser = createUserWithId(2L, "other@test.com", "다른유저");
+        post = createPostWithId(100L, user);
+        party = createPartyWithId(1L, 100L, 1L);
+    }
+
+    private User createUserWithId(Long id, String email, String nickname) {
+        User user = User.builder()
+                .email(email)
+                .password("password123")
+                .nickname(nickname)
+                .verificationCode("VERIFIED")
+                .build();
+        setId(user, id, User.class);
+        return user;
+    }
+
+    private Post createPostWithId(Long id, User user) {
+        Post post = Post.builder()
+                .user(user)
+                .gameMode(GameMode.SUMMONERS_RIFT)
+                .queueType(QueueType.DUO)
+                .myPosition(Position.TOP)
+                .lookingPositions("[\"JUNGLE\"]")
+                .mic(true)
+                .recruitCount(2)
+                .memo("테스트 모집글")
+                .build();
+        setId(post, id, Post.class);
+        return post;
+    }
+
+    private Party createPartyWithId(Long id, Long postId, Long leaderId) {
+        Party party = new Party(postId, leaderId);
+        setId(party, id, Party.class);
+        return party;
+    }
+
+    private void setId(Object entity, Long id, Class<?> clazz) {
+        try {
+            var idField = clazz.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setIsActive(Post post, boolean isActive) {
+        try {
+            var field = post.getClass().getSuperclass().getSuperclass().getDeclaredField("isActive");
+            field.setAccessible(true);
+            field.set(post, isActive);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("모집글 수정 테스트")
+    class UpdatePostTest {
+
+        @Test
+        @DisplayName("성공: 작성자가 모집글 수정")
+        void updatePost_success() {
+            // given
+            PostUpdateRequest request = new PostUpdateRequest(
+                    Position.MID,
+                    List.of(Position.ADC),
+                    QueueType.DUO,
+                    false,
+                    2,
+                    "수정된 메모"
+            );
+            PostUpdateResponse expectedResponse = mock(PostUpdateResponse.class);
+
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doNothing().when(postValidator).validatePostOwner(post, 1L);
+            given(postListFacade.updatePostWithPartyView(post, request)).willReturn(expectedResponse);
+
+            // when
+            PostUpdateResponse result = postService.updatePost(100L, request, 1L);
+
+            // then
+            assertThat(result).isEqualTo(expectedResponse);
+            verify(postValidator).validatePostOwner(post, 1L);
+            verify(postListFacade).updatePostWithPartyView(post, request);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 모집글")
+        void updatePost_fail_not_found() {
+            // given
+            PostUpdateRequest request = new PostUpdateRequest(
+                    Position.MID, List.of(Position.ADC), QueueType.DUO, false, 2, "메모"
+            );
+            given(postRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> postService.updatePost(999L, request, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 이미 삭제된 모집글")
+        void updatePost_fail_already_deleted() {
+            // given
+            setIsActive(post, false);
+            PostUpdateRequest request = new PostUpdateRequest(
+                    Position.MID, List.of(Position.ADC), QueueType.DUO, false, 2, "메모"
+            );
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+
+            // when & then
+            assertThatThrownBy(() -> postService.updatePost(100L, request, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_ALREADY_DELETED);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 작성자가 아닌 유저가 수정 시도")
+        void updatePost_fail_not_owner() {
+            // given
+            PostUpdateRequest request = new PostUpdateRequest(
+                    Position.MID, List.of(Position.ADC), QueueType.DUO, false, 2, "메모"
+            );
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doThrow(new CustomException(CustomErrorCode.POST_FORBIDDEN))
+                    .when(postValidator).validatePostOwner(post, 2L);
+
+            // when & then
+            assertThatThrownBy(() -> postService.updatePost(100L, request, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_FORBIDDEN);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("모집글 상태 변경 테스트")
+    class UpdatePostStatusTest {
+
+        @Test
+        @DisplayName("성공: 작성자가 상태를 CLOSED로 변경")
+        void updatePostStatus_success() {
+            // given
+            PostStatusUpdateRequest request = new PostStatusUpdateRequest(PostStatus.CLOSED);
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doNothing().when(postValidator).validatePostOwner(post, 1L);
+            doNothing().when(postValidator).validateStatusUpdateAllowed(PostStatus.CLOSED);
+
+            // when
+            PostStatusUpdateResponse result = postService.updatePostStatus(100L, request, 1L);
+
+            // then
+            assertThat(result.postId()).isEqualTo(100L);
+            assertThat(result.status()).isEqualTo(PostStatus.CLOSED);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 모집글")
+        void updatePostStatus_fail_not_found() {
+            // given
+            PostStatusUpdateRequest request = new PostStatusUpdateRequest(PostStatus.CLOSED);
+            given(postRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> postService.updatePostStatus(999L, request, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: CLOSED 외 상태로 변경 시도")
+        void updatePostStatus_fail_invalid_status() {
+            // given
+            PostStatusUpdateRequest request = new PostStatusUpdateRequest(PostStatus.RECRUIT);
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doNothing().when(postValidator).validatePostOwner(post, 1L);
+            doThrow(new CustomException(CustomErrorCode.INVALID_POST_STATUS_UPDATE))
+                    .when(postValidator).validateStatusUpdateAllowed(PostStatus.RECRUIT);
+
+            // when & then
+            assertThatThrownBy(() -> postService.updatePostStatus(100L, request, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.INVALID_POST_STATUS_UPDATE);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("모집글 단건 조회 테스트")
+    class GetPostDetailTest {
+
+        @Test
+        @DisplayName("성공: 모집글 상세 조회")
+        void getPostDetail_success() {
+            // given
+            PostUpdateResponse expectedResponse = mock(PostUpdateResponse.class);
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            given(postListFacade.buildPostDetailForEdit(post)).willReturn(expectedResponse);
+
+            // when
+            PostUpdateResponse result = postService.getPostDetail(100L, 1L);
+
+            // then
+            assertThat(result).isEqualTo(expectedResponse);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 모집글")
+        void getPostDetail_fail_not_found() {
+            // given
+            given(postRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> postService.getPostDetail(999L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 이미 삭제된 모집글")
+        void getPostDetail_fail_already_deleted() {
+            // given
+            setIsActive(post, false);
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+
+            // when & then
+            assertThatThrownBy(() -> postService.getPostDetail(100L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_ALREADY_DELETED);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("모집글 삭제 테스트")
+    class DeletePostTest {
+
+        @Test
+        @DisplayName("성공: 작성자가 모집글 삭제")
+        void deletePost_success() {
+            // given
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doNothing().when(postValidator).validatePostOwner(post, 1L);
+            given(partyRepository.findByPostId(100L)).willReturn(Optional.of(party));
+
+            // when
+            PostDeleteResponse result = postService.deletePost(100L, 1L);
+
+            // then
+            assertThat(result.postId()).isEqualTo(100L);
+            assertThat(result.deleted()).isTrue();
+            verify(postRepository).save(post);
+            verify(partyRepository).save(party);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 모집글")
+        void deletePost_fail_not_found() {
+            // given
+            given(postRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> postService.deletePost(999L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 작성자가 아닌 유저가 삭제 시도")
+        void deletePost_fail_not_owner() {
+            // given
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doThrow(new CustomException(CustomErrorCode.POST_FORBIDDEN))
+                    .when(postValidator).validatePostOwner(post, 2L);
+
+            // when & then
+            assertThatThrownBy(() -> postService.deletePost(100L, 2L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_FORBIDDEN);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 이미 삭제된 모집글")
+        void deletePost_fail_already_deleted() {
+            // given
+            setIsActive(post, false);
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doNothing().when(postValidator).validatePostOwner(post, 1L);
+
+            // when & then
+            assertThatThrownBy(() -> postService.deletePost(100L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.POST_ALREADY_DELETED);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 연관된 파티가 없음")
+        void deletePost_fail_party_not_found() {
+            // given
+            given(postRepository.findById(100L)).willReturn(Optional.of(post));
+            doNothing().when(postValidator).validatePostOwner(post, 1L);
+            given(partyRepository.findByPostId(100L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> postService.deletePost(100L, 1L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.PARTY_NOT_FOUND);
+                    });
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/back/matchduo/domain/review/controller/ReviewControllerTest.java
@@ -1,0 +1,420 @@
+package com.back.matchduo.domain.review.controller;
+
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.gameaccount.repository.GameAccountRepository;
+import com.back.matchduo.domain.party.entity.Party;
+import com.back.matchduo.domain.party.entity.PartyMember;
+import com.back.matchduo.domain.party.entity.PartyMemberRole;
+import com.back.matchduo.domain.party.repository.PartyMemberRepository;
+import com.back.matchduo.domain.party.repository.PartyRepository;
+import com.back.matchduo.domain.post.entity.GameMode;
+import com.back.matchduo.domain.post.entity.Position;
+import com.back.matchduo.domain.post.entity.Post;
+import com.back.matchduo.domain.post.entity.PostStatus;
+import com.back.matchduo.domain.post.entity.QueueType;
+import com.back.matchduo.domain.post.repository.PostRepository;
+import com.back.matchduo.domain.review.dto.request.ReviewCreateRequest;
+import com.back.matchduo.domain.review.entity.Review;
+import com.back.matchduo.domain.review.entity.ReviewRequest;
+import com.back.matchduo.domain.review.enums.ReviewEmoji;
+import com.back.matchduo.domain.review.enums.ReviewRequestStatus;
+import com.back.matchduo.domain.review.repository.ReviewRepository;
+import com.back.matchduo.domain.review.repository.ReviewRequestRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.security.CustomUserDetails;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Review API 통합 테스트")
+class ReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private PartyRepository partyRepository;
+
+    @Autowired
+    private PartyMemberRepository partyMemberRepository;
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Autowired
+    private ReviewRequestRepository reviewRequestRepository;
+
+    @Autowired
+    private GameAccountRepository gameAccountRepository;
+
+    private User reviewer;
+    private User reviewee;
+    private User thirdUser;
+    private GameAccount testGameAccount;
+    private Post testPost;
+    private Party testParty;
+    private ReviewRequest completedReviewRequest;
+    private ReviewRequest pendingReviewRequest;
+    private Review existingReview;
+
+    @BeforeAll
+    void setUp() {
+        // 유저 생성
+        reviewer = User.builder()
+                .email("reviewer@test.com")
+                .password("password123")
+                .nickname("리뷰작성자")
+                .verificationCode("VERIFIED")
+                .build();
+        userRepository.save(reviewer);
+
+        reviewee = User.builder()
+                .email("reviewee@test.com")
+                .password("password123")
+                .nickname("리뷰대상자")
+                .verificationCode("VERIFIED")
+                .build();
+        userRepository.save(reviewee);
+
+        thirdUser = User.builder()
+                .email("third@test.com")
+                .password("password123")
+                .nickname("제3자")
+                .verificationCode("VERIFIED")
+                .build();
+        userRepository.save(thirdUser);
+
+        // 테스트 게임 계정 생성
+        testGameAccount = GameAccount.builder()
+                .gameNickname("리뷰테스트게이머")
+                .gameTag("KR1")
+                .gameType("LOL")
+                .puuid("review-test-puuid-12345")
+                .profileIconId(1234)
+                .user(reviewer)
+                .build();
+        gameAccountRepository.save(testGameAccount);
+
+        // 모집글 생성 (CLOSED 상태 - 게임 종료)
+        testPost = Post.builder()
+                .user(reviewer)
+                .gameAccount(testGameAccount)
+                .gameMode(GameMode.SUMMONERS_RIFT)
+                .queueType(QueueType.DUO)
+                .myPosition(Position.TOP)
+                .lookingPositions("[\"JUNGLE\"]")
+                .mic(true)
+                .recruitCount(2)
+                .memo("리뷰 테스트용 모집글")
+                .build();
+        postRepository.save(testPost);
+        testPost.updateStatus(PostStatus.CLOSED);
+        postRepository.save(testPost);
+
+        // 파티 생성 (CLOSED 상태)
+        testParty = new Party(testPost.getId(), reviewer.getId());
+        testParty.closeParty();
+        partyRepository.save(testParty);
+
+        // 파티 멤버 추가
+        partyMemberRepository.save(new PartyMember(testParty, reviewer, PartyMemberRole.LEADER));
+        partyMemberRepository.save(new PartyMember(testParty, reviewee, PartyMemberRole.MEMBER));
+
+        // 리뷰 요청 생성 (COMPLETED - 리뷰 작성 가능)
+        completedReviewRequest = ReviewRequest.builder()
+                .party(testParty)
+                .requestUser(reviewer)
+                .build();
+        completedReviewRequest.complete(); // COMPLETED 상태로 변경
+        reviewRequestRepository.save(completedReviewRequest);
+
+        // 리뷰 요청 생성 (PENDING - 리뷰 작성 불가)
+        pendingReviewRequest = ReviewRequest.builder()
+                .party(testParty)
+                .requestUser(thirdUser)
+                .build();
+        // PENDING 상태 유지
+        reviewRequestRepository.save(pendingReviewRequest);
+
+        // 기존 리뷰 생성 (모든 리뷰 조회 테스트용)
+        existingReview = Review.builder()
+                .party(testParty)
+                .reviewer(reviewer)
+                .reviewee(reviewee)
+                .reviewRequest(completedReviewRequest)
+                .emoji(ReviewEmoji.GOOD)
+                .content("좋은 팀원이었습니다!")
+                .build();
+        reviewRepository.save(existingReview);
+    }
+
+    @Nested
+    @DisplayName("모든 리뷰 조회 API (GET /api/v1/reviews)")
+    class GetAllReviews {
+
+        @Test
+        @DisplayName("성공: 비로그인 상태에서 모든 리뷰 조회 (permitAll)")
+        void success_get_all_reviews_guest() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andExpect(jsonPath("$[0].reviewId").exists())
+                    .andExpect(jsonPath("$[0].reviewerNickname").exists())
+                    .andExpect(jsonPath("$[0].emoji").exists())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: 로그인 상태에서 모든 리뷰 조회")
+        void success_get_all_reviews_authenticated() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(reviewer)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("특정 유저가 받은 리뷰 조회 API (GET /api/v1/reviews/users/{userId})")
+    class GetReviewsByUser {
+
+        @Test
+        @DisplayName("성공: 비로그인 상태에서 특정 유저 리뷰 조회 (permitAll)")
+        void success_get_user_reviews_guest() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/users/{userId}", reviewee.getId())
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: 리뷰가 없는 유저 조회시 빈 배열 반환")
+        void success_get_empty_reviews() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/users/{userId}", thirdUser.getId())
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andExpect(jsonPath("$").isEmpty())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 요청 관리 목록 조회 API (GET /api/v1/reviews/requests)")
+    class GetWritableReviewRequests {
+
+        @Test
+        @DisplayName("성공: COMPLETED 상태인 리뷰 요청만 조회된다")
+        void success_get_completed_review_requests() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/requests")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(reviewer)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: PENDING 상태 요청만 있는 유저는 빈 배열 반환")
+        void success_get_empty_when_only_pending() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/requests")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(thirdUser)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andExpect(jsonPath("$").isEmpty())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: 비로그인 상태에서 접근시 401 Unauthorized")
+        void fail_unauthorized() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/requests")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("내 리뷰 작성 목록 조회 API (GET /api/v1/reviews/me)")
+    class GetMyWrittenReviews {
+
+        @Test
+        @DisplayName("성공: 내가 작성한 리뷰 목록 조회")
+        void success_get_my_reviews() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/me")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(reviewer)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andExpect(jsonPath("$[0].revieweeNickname").value("리뷰대상자"))
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("성공: 작성한 리뷰가 없으면 빈 배열 반환")
+        void success_get_empty_my_reviews() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/me")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .with(user(new CustomUserDetails(thirdUser)))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$").isArray())
+                    .andExpect(jsonPath("$").isEmpty())
+                    .andDo(print());
+        }
+
+        @Test
+        @DisplayName("실패: 비로그인 상태에서 접근시 401 Unauthorized")
+        void fail_unauthorized() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/me")
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 비율 분포 조회 API (GET /api/v1/reviews/users/{userId}/distribution)")
+    class GetReviewDistribution {
+
+        @Test
+        @DisplayName("성공: 비로그인 상태에서 리뷰 분포 조회 (permitAll)")
+        void success_get_distribution_guest() throws Exception {
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    get("/api/v1/reviews/users/{userId}/distribution", reviewee.getId())
+                            .accept(MediaType.APPLICATION_JSON)
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.totalReviews").exists())
+                    .andExpect(jsonPath("$.ratios.GOOD").exists())
+                    .andExpect(jsonPath("$.ratios.NORMAL").exists())
+                    .andExpect(jsonPath("$.ratios.BAD").exists())
+                    .andDo(print());
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 작성 API (POST /api/v1/reviews)")
+    class CreateReview {
+
+        @Test
+        @DisplayName("실패: 비로그인 상태에서 리뷰 작성 시도시 401 Unauthorized")
+        void fail_create_review_unauthorized() throws Exception {
+            // given
+            ReviewCreateRequest request = new ReviewCreateRequest(
+                    testParty.getId(),
+                    reviewee.getId(),
+                    ReviewEmoji.GOOD,
+                    "테스트 리뷰"
+            );
+
+            // when
+            ResultActions resultActions = mockMvc.perform(
+                    post("/api/v1/reviews")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(request))
+            );
+
+            // then
+            resultActions
+                    .andExpect(status().isUnauthorized())
+                    .andDo(print());
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/review/service/ReviewServiceTest.java
@@ -1,0 +1,296 @@
+package com.back.matchduo.domain.review.service;
+
+import com.back.matchduo.domain.party.entity.Party;
+import com.back.matchduo.domain.party.repository.PartyMemberRepository;
+import com.back.matchduo.domain.review.dto.request.ReviewCreateRequest;
+import com.back.matchduo.domain.review.dto.response.ReviewCreateResponse;
+import com.back.matchduo.domain.review.dto.response.ReviewDistributionResponse;
+import com.back.matchduo.domain.review.dto.response.ReviewListResponse;
+import com.back.matchduo.domain.review.entity.Review;
+import com.back.matchduo.domain.review.entity.ReviewRequest;
+import com.back.matchduo.domain.review.enums.ReviewEmoji;
+import com.back.matchduo.domain.review.enums.ReviewRequestStatus;
+import com.back.matchduo.domain.review.repository.ReviewRepository;
+import com.back.matchduo.domain.review.repository.ReviewRequestRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomErrorCode;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReviewService 단위 테스트")
+class ReviewServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReviewRequestRepository reviewRequestRepository;
+
+    @Mock
+    private PartyMemberRepository partyMemberRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    private User reviewer;
+    private User reviewee;
+    private Party party;
+    private ReviewRequest reviewRequest;
+
+    @BeforeEach
+    void setUp() {
+        reviewer = createUserWithId(1L, "reviewer@test.com", "리뷰작성자");
+        reviewee = createUserWithId(2L, "reviewee@test.com", "리뷰대상자");
+        party = createPartyWithId(1L, 100L, 1L);
+        reviewRequest = createReviewRequest(1L, party, reviewer, ReviewRequestStatus.COMPLETED);
+    }
+
+    private User createUserWithId(Long id, String email, String nickname) {
+        User user = User.builder()
+                .email(email)
+                .password("password123")
+                .nickname(nickname)
+                .verificationCode("VERIFIED")
+                .build();
+        setId(user, id);
+        return user;
+    }
+
+    private Party createPartyWithId(Long id, Long postId, Long leaderId) {
+        Party party = new Party(postId, leaderId);
+        setId(party, id);
+        return party;
+    }
+
+    private ReviewRequest createReviewRequest(Long id, Party party, User requestUser, ReviewRequestStatus status) {
+        ReviewRequest request = ReviewRequest.builder()
+                .party(party)
+                .requestUser(requestUser)
+                .build();
+        if (status == ReviewRequestStatus.COMPLETED) {
+            request.complete();
+        }
+        setId(request, id);
+        return request;
+    }
+
+    private void setId(Object entity, Long id) {
+        try {
+            var idField = entity.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(entity, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 작성 테스트")
+    class CreateReviewTest {
+
+        @Test
+        @DisplayName("성공: 유효한 리뷰 작성")
+        void createReview_success() {
+            // given
+            ReviewCreateRequest request = new ReviewCreateRequest(1L, 2L, ReviewEmoji.GOOD, "좋은 팀원이었습니다!");
+
+            given(reviewRequestRepository.findByPartyIdAndRequestUserId(1L, 1L))
+                    .willReturn(Optional.of(reviewRequest));
+            given(reviewRepository.existsByPartyIdAndReviewerIdAndRevieweeId(1L, 1L, 2L))
+                    .willReturn(false);
+            given(partyMemberRepository.existsByPartyIdAndUserId(1L, 2L))
+                    .willReturn(true);
+            given(userRepository.findById(2L))
+                    .willReturn(Optional.of(reviewee));
+            given(reviewRepository.save(any(Review.class)))
+                    .willAnswer(invocation -> {
+                        Review review = invocation.getArgument(0);
+                        setId(review, 1L);
+                        return review;
+                    });
+            given(partyMemberRepository.countByPartyId(1L)).willReturn(3L);
+            given(reviewRepository.countByPartyIdAndReviewerId(1L, 1L)).willReturn(1L);
+
+            // when
+            ReviewCreateResponse result = reviewService.createReview(1L, request);
+
+            // then
+            assertThat(result).isNotNull();
+            verify(reviewRepository).save(any(Review.class));
+        }
+
+        @Test
+        @DisplayName("실패: 리뷰 요청이 COMPLETED 상태가 아님")
+        void createReview_fail_not_completed() {
+            // given
+            ReviewRequest pendingRequest = ReviewRequest.builder()
+                    .party(party)
+                    .requestUser(reviewer)
+                    .build();
+            setId(pendingRequest, 1L);
+
+            ReviewCreateRequest request = new ReviewCreateRequest(1L, 2L, ReviewEmoji.GOOD, "리뷰");
+
+            given(reviewRequestRepository.findByPartyIdAndRequestUserId(1L, 1L))
+                    .willReturn(Optional.of(pendingRequest));
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.createReview(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.MATCH_NOT_END);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 이미 리뷰를 작성함")
+        void createReview_fail_already_written() {
+            // given
+            ReviewCreateRequest request = new ReviewCreateRequest(1L, 2L, ReviewEmoji.GOOD, "리뷰");
+
+            given(reviewRequestRepository.findByPartyIdAndRequestUserId(1L, 1L))
+                    .willReturn(Optional.of(reviewRequest));
+            given(reviewRepository.existsByPartyIdAndReviewerIdAndRevieweeId(1L, 1L, 2L))
+                    .willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.createReview(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.REVIEW_ALREADY_WRITTEN);
+                    });
+        }
+
+        @Test
+        @DisplayName("실패: 리뷰 대상자가 파티원이 아님")
+        void createReview_fail_not_party_member() {
+            // given
+            ReviewCreateRequest request = new ReviewCreateRequest(1L, 2L, ReviewEmoji.GOOD, "리뷰");
+
+            given(reviewRequestRepository.findByPartyIdAndRequestUserId(1L, 1L))
+                    .willReturn(Optional.of(reviewRequest));
+            given(reviewRepository.existsByPartyIdAndReviewerIdAndRevieweeId(1L, 1L, 2L))
+                    .willReturn(false);
+            given(partyMemberRepository.existsByPartyIdAndUserId(1L, 2L))
+                    .willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.createReview(1L, request))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.PARTY_MEMBER_NOT_MATCH);
+                    });
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 조회 테스트")
+    class GetReviewsTest {
+
+        @Test
+        @DisplayName("성공: 특정 유저가 받은 리뷰 목록 조회")
+        void getReviewsReceivedByUser_success() {
+            // given
+            Review review = Review.builder()
+                    .party(party)
+                    .reviewer(reviewer)
+                    .reviewee(reviewee)
+                    .reviewRequest(reviewRequest)
+                    .emoji(ReviewEmoji.GOOD)
+                    .content("좋은 팀원!")
+                    .build();
+            setId(review, 1L);
+
+            given(reviewRepository.findAllByRevieweeId(2L))
+                    .willReturn(List.of(review));
+
+            // when
+            List<ReviewListResponse> result = reviewService.getReviewsReceivedByUser(2L);
+
+            // then
+            assertThat(result).hasSize(1);
+            verify(reviewRepository).findAllByRevieweeId(2L);
+        }
+
+        @Test
+        @DisplayName("성공: 리뷰가 없으면 빈 리스트 반환")
+        void getReviewsReceivedByUser_empty() {
+            // given
+            given(reviewRepository.findAllByRevieweeId(999L))
+                    .willReturn(List.of());
+
+            // when
+            List<ReviewListResponse> result = reviewService.getReviewsReceivedByUser(999L);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 분포 조회 테스트")
+    class GetDistributionTest {
+
+        @Test
+        @DisplayName("성공: 리뷰 분포 비율 계산")
+        void getReviewDistribution_success() {
+            // given
+            given(userRepository.findById(2L)).willReturn(Optional.of(reviewee));
+            given(reviewRepository.countReviewEmojisByRevieweeId(2L))
+                    .willReturn(List.of(
+                            new Object[]{ReviewEmoji.GOOD, 7L},
+                            new Object[]{ReviewEmoji.NORMAL, 2L},
+                            new Object[]{ReviewEmoji.BAD, 1L}
+                    ));
+
+            // when
+            ReviewDistributionResponse result = reviewService.getReviewDistribution(2L);
+
+            // then
+            assertThat(result.totalReviews()).isEqualTo(10);
+            assertThat(result.ratios().good()).isEqualTo(70.0);
+            assertThat(result.ratios().normal()).isEqualTo(20.0);
+            assertThat(result.ratios().bad()).isEqualTo(10.0);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 유저")
+        void getReviewDistribution_fail_user_not_found() {
+            // given
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.getReviewDistribution(999L))
+                    .isInstanceOf(CustomException.class)
+                    .satisfies(ex -> {
+                        CustomException customEx = (CustomException) ex;
+                        assertThat(customEx.getErrorCode()).isEqualTo(CustomErrorCode.NOT_FOUND_USER);
+                    });
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/user/service/UserProfileServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/user/service/UserProfileServiceTest.java
@@ -1,0 +1,305 @@
+package com.back.matchduo.domain.user.service;
+
+import com.back.matchduo.domain.user.dto.request.UserUpdatePasswordRequest;
+import com.back.matchduo.domain.user.dto.response.UserProfileResponse;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserProfileService 테스트")
+class UserProfileServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FileStorageService fileStorageService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserProfileService userProfileService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .password("$2a$10$encodedPassword")
+                .nickname("테스터")
+                .verificationCode("VERIFIED")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("프로필 조회")
+    class GetProfileTest {
+
+        @Test
+        @DisplayName("성공: 프로필 조회")
+        void getProfile_success() {
+            // given
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.of(testUser));
+
+            // when
+            UserProfileResponse response = userProfileService.getProfile(testUser);
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.email()).isEqualTo(testUser.getEmail());
+            assertThat(response.nickname()).isEqualTo(testUser.getNickname());
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자")
+        void getProfile_fail_userNotFound() {
+            // given
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userProfileService.getProfile(testUser))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("닉네임 수정")
+    class UpdateNicknameTest {
+
+        @Test
+        @DisplayName("성공: 정상적인 닉네임 수정")
+        void updateNickname_success() {
+            // given
+            String newNickname = "새닉네임";
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.of(testUser));
+            given(userRepository.existsByNickname(newNickname)).willReturn(false);
+
+            // when
+            userProfileService.updateNickname(testUser, newNickname);
+
+            // then
+            assertThat(testUser.getNickname()).isEqualTo(newNickname);
+            assertThat(testUser.getNicknameUpdatedAt()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("실패: null 닉네임")
+        void updateNickname_fail_null() {
+            assertThatThrownBy(() -> userProfileService.updateNickname(testUser, null))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 빈 닉네임")
+        void updateNickname_fail_empty() {
+            assertThatThrownBy(() -> userProfileService.updateNickname(testUser, "  "))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 형식에 맞지 않는 닉네임 (1글자)")
+        void updateNickname_fail_tooShort() {
+            assertThatThrownBy(() -> userProfileService.updateNickname(testUser, "가"))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 형식에 맞지 않는 닉네임 (9글자 이상)")
+        void updateNickname_fail_tooLong() {
+            assertThatThrownBy(() -> userProfileService.updateNickname(testUser, "닉네임이너무길어요"))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 비속어 포함")
+        void updateNickname_fail_bannedWord() {
+            assertThatThrownBy(() -> userProfileService.updateNickname(testUser, "병신테스트"))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 중복된 닉네임")
+        void updateNickname_fail_duplicate() {
+            // given
+            String duplicateNickname = "중복닉네임";
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.of(testUser));
+            given(userRepository.existsByNickname(duplicateNickname)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userProfileService.updateNickname(testUser, duplicateNickname))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("자기소개 수정")
+    class UpdateCommentTest {
+
+        @BeforeEach
+        void setUp() {
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.of(testUser));
+        }
+
+        @Test
+        @DisplayName("성공: 자기소개 수정")
+        void updateComment_success() {
+            // given
+            String newComment = "새로운 자기소개입니다.";
+
+            // when
+            userProfileService.updateComment(testUser, newComment);
+
+            // then
+            assertThat(testUser.getComment()).isEqualTo(newComment);
+        }
+
+        @Test
+        @DisplayName("성공: 자기소개 삭제 (null)")
+        void updateComment_success_null() {
+            // when
+            userProfileService.updateComment(testUser, null);
+
+            // then
+            assertThat(testUser.getComment()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호 변경")
+    class UpdatePasswordTest {
+
+        @Test
+        @DisplayName("성공: 비밀번호 변경")
+        void updatePassword_success() {
+            // given
+            String currentPassword = "currentPass123!";
+            String newPassword = "newPassword123!";
+            UserUpdatePasswordRequest request = new UserUpdatePasswordRequest(
+                    currentPassword, newPassword, newPassword
+            );
+
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.of(testUser));
+            given(passwordEncoder.matches(currentPassword, testUser.getPassword())).willReturn(true);
+            given(passwordEncoder.encode(newPassword)).willReturn("$2a$10$newEncodedPassword");
+
+            // when
+            userProfileService.updatePassword(testUser, request);
+
+            // then
+            verify(passwordEncoder).encode(newPassword);
+        }
+
+        @Test
+        @DisplayName("실패: 새 비밀번호 불일치")
+        void updatePassword_fail_mismatch() {
+            // given
+            UserUpdatePasswordRequest request = new UserUpdatePasswordRequest(
+                    "currentPass123!", "newPassword123!", "differentPassword123!"
+            );
+
+            // when & then
+            assertThatThrownBy(() -> userProfileService.updatePassword(testUser, request))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 현재 비밀번호 틀림")
+        void updatePassword_fail_wrongCurrentPassword() {
+            // given
+            String wrongPassword = "wrongPassword123!";
+            String newPassword = "newPassword123!";
+            UserUpdatePasswordRequest request = new UserUpdatePasswordRequest(
+                    wrongPassword, newPassword, newPassword
+            );
+
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.of(testUser));
+            given(passwordEncoder.matches(wrongPassword, testUser.getPassword())).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> userProfileService.updatePassword(testUser, request))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("실패: 비밀번호 형식 오류")
+        void updatePassword_fail_invalidFormat() {
+            // given
+            UserUpdatePasswordRequest request = new UserUpdatePasswordRequest(
+                    "currentPass123!", "short", "short"
+            );
+
+            // when & then
+            assertThatThrownBy(() -> userProfileService.updatePassword(testUser, request))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 이미지 수정")
+    class UpdateProfileImageTest {
+
+        @Mock
+        private MultipartFile mockFile;
+
+        @BeforeEach
+        void setUp() {
+            given(userRepository.findById(testUser.getId())).willReturn(Optional.of(testUser));
+        }
+
+        @Test
+        @DisplayName("성공: 프로필 이미지 업로드")
+        void updateProfileImage_success() {
+            // given
+            String newImageUrl = "/uploads/profile/new-image.png";
+            given(fileStorageService.upload(mockFile)).willReturn(newImageUrl);
+
+            // when
+            userProfileService.updateProfileImage(testUser, mockFile);
+
+            // then
+            assertThat(testUser.getProfileImage()).isEqualTo(newImageUrl);
+            verify(fileStorageService).upload(mockFile);
+        }
+
+        @Test
+        @DisplayName("성공: 기존 이미지 삭제 후 새 이미지 업로드")
+        void updateProfileImage_success_deleteOldImage() {
+            // given
+            String oldImageUrl = "/uploads/profile/old-image.png";
+            testUser.updateProfileImage(oldImageUrl);
+
+            String newImageUrl = "/uploads/profile/new-image.png";
+            given(fileStorageService.upload(mockFile)).willReturn(newImageUrl);
+
+            // when
+            userProfileService.updateProfileImage(testUser, mockFile);
+
+            // then
+            verify(fileStorageService).delete(oldImageUrl);
+            verify(fileStorageService).upload(mockFile);
+            assertThat(testUser.getProfileImage()).isEqualTo(newImageUrl);
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/user/service/UserSignUpServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/user/service/UserSignUpServiceTest.java
@@ -1,0 +1,145 @@
+package com.back.matchduo.domain.user.service;
+
+import com.back.matchduo.domain.user.dto.request.UserSignUpRequest;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserSignUpService 테스트")
+class UserSignUpServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserSignUpService userSignUpService;
+
+    private static final String TEST_EMAIL = "test@example.com";
+    private static final String TEST_PASSWORD = "password123!";
+    private static final String ENCODED_PASSWORD = "$2a$10$encodedPassword";
+
+    @Nested
+    @DisplayName("회원가입")
+    class SignUpTest {
+
+        @Test
+        @DisplayName("성공: 정상적인 회원가입")
+        void signUp_success() {
+            // given
+            UserSignUpRequest request = new UserSignUpRequest(
+                    TEST_EMAIL, TEST_PASSWORD, TEST_PASSWORD, "123456"
+            );
+
+            given(userRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+            given(emailService.isVerified(TEST_EMAIL)).willReturn(true);
+            given(passwordEncoder.encode(TEST_PASSWORD)).willReturn(ENCODED_PASSWORD);
+            given(userRepository.existsByNickname(anyString())).willReturn(false);
+            given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            userSignUpService.signUp(request);
+
+            // then
+            verify(userRepository).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("실패: 중복된 이메일")
+        void signUp_fail_duplicateEmail() {
+            // given
+            UserSignUpRequest request = new UserSignUpRequest(
+                    TEST_EMAIL, TEST_PASSWORD, TEST_PASSWORD, "123456"
+            );
+
+            given(userRepository.existsByEmail(TEST_EMAIL)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userSignUpService.signUp(request))
+                    .isInstanceOf(CustomException.class);
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("실패: 이메일 미인증")
+        void signUp_fail_emailNotVerified() {
+            // given
+            UserSignUpRequest request = new UserSignUpRequest(
+                    TEST_EMAIL, TEST_PASSWORD, TEST_PASSWORD, "123456"
+            );
+
+            given(userRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+            given(emailService.isVerified(TEST_EMAIL)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> userSignUpService.signUp(request))
+                    .isInstanceOf(CustomException.class);
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("실패: 비밀번호 불일치")
+        void signUp_fail_passwordMismatch() {
+            // given
+            UserSignUpRequest request = new UserSignUpRequest(
+                    TEST_EMAIL, TEST_PASSWORD, "differentPassword!", "123456"
+            );
+
+            given(userRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+            given(emailService.isVerified(TEST_EMAIL)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userSignUpService.signUp(request))
+                    .isInstanceOf(CustomException.class);
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("성공: 닉네임 중복 시 숫자 추가")
+        void signUp_success_duplicateNickname() {
+            // given
+            UserSignUpRequest request = new UserSignUpRequest(
+                    TEST_EMAIL, TEST_PASSWORD, TEST_PASSWORD, "123456"
+            );
+
+            given(userRepository.existsByEmail(TEST_EMAIL)).willReturn(false);
+            given(emailService.isVerified(TEST_EMAIL)).willReturn(true);
+            given(passwordEncoder.encode(TEST_PASSWORD)).willReturn(ENCODED_PASSWORD);
+            // 첫 번째 닉네임은 중복, 두 번째는 사용 가능
+            given(userRepository.existsByNickname("test")).willReturn(true);
+            given(userRepository.existsByNickname("test_1")).willReturn(false);
+            given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            userSignUpService.signUp(request);
+
+            // then
+            verify(userRepository).save(any(User.class));
+        }
+    }
+}

--- a/src/test/java/com/back/matchduo/domain/usersearch/service/UserSearchServiceTest.java
+++ b/src/test/java/com/back/matchduo/domain/usersearch/service/UserSearchServiceTest.java
@@ -1,0 +1,216 @@
+package com.back.matchduo.domain.usersearch.service;
+
+import com.back.matchduo.domain.gameaccount.entity.GameAccount;
+import com.back.matchduo.domain.gameaccount.repository.GameAccountRepository;
+import com.back.matchduo.domain.user.entity.User;
+import com.back.matchduo.domain.user.repository.UserRepository;
+import com.back.matchduo.domain.usersearch.dto.response.UserSearchListResponse;
+import com.back.matchduo.global.exeption.CustomException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+@DisplayName("UserSearchService 테스트")
+class UserSearchServiceTest {
+
+    @Autowired
+    private UserSearchService userSearchService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameAccountRepository gameAccountRepository;
+
+    private User userWithGameAccount;
+    private User userWithoutGameAccount;
+
+    @BeforeEach
+    void setUp() {
+        userWithGameAccount = userRepository.save(User.builder()
+                .email("gamer@test.com")
+                .password("password123")
+                .nickname("프로게이머")
+                .verificationCode("1234")
+                .comment("게임 좋아합니다")
+                .build());
+
+        gameAccountRepository.save(GameAccount.builder()
+                .gameNickname("TestPlayer")
+                .gameTag("KR1")
+                .gameType("LEAGUE_OF_LEGENDS")
+                .puuid("test-puuid-12345")
+                .profileIconId(1234)
+                .user(userWithGameAccount)
+                .build());
+
+        userWithoutGameAccount = userRepository.save(User.builder()
+                .email("normal@test.com")
+                .password("password123")
+                .nickname("일반유저")
+                .verificationCode("5678")
+                .build());
+    }
+
+    @Nested
+    @DisplayName("검색 유효성 검사")
+    class ValidationTest {
+
+        @Test
+        @DisplayName("null 검색어 시 예외 발생")
+        void search_null_keyword_throws_exception() {
+            assertThatThrownBy(() -> userSearchService.search(null, null, 10))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        @DisplayName("빈 검색어 시 예외 발생")
+        void search_blank_keyword_throws_exception() {
+            assertThatThrownBy(() -> userSearchService.search("   ", null, 10))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("검색 결과")
+    class SearchResultTest {
+
+        @Test
+        @DisplayName("닉네임으로 검색 성공")
+        void search_by_nickname_success() {
+            // when
+            UserSearchListResponse result = userSearchService.search("게이머", null, 10);
+
+            // then
+            assertThat(result.totalCount()).isEqualTo(1);
+            assertThat(result.users()).hasSize(1);
+            assertThat(result.users().get(0).nickname()).isEqualTo("프로게이머");
+        }
+
+        @Test
+        @DisplayName("검색 결과 없음")
+        void search_no_result() {
+            // when
+            UserSearchListResponse result = userSearchService.search("존재하지않는닉네임", null, 10);
+
+            // then
+            assertThat(result.totalCount()).isZero();
+            assertThat(result.users()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("게임 계정 연동된 유저 검색")
+        void search_user_with_game_account() {
+            // when
+            UserSearchListResponse result = userSearchService.search("프로게이머", null, 10);
+
+            // then
+            assertThat(result.users()).hasSize(1);
+            UserSearchListResponse.GameAccountDto gameAccount = result.users().get(0).gameAccount();
+            assertThat(gameAccount.linked()).isTrue();
+            assertThat(gameAccount.gameName()).isEqualTo("TestPlayer");
+            assertThat(gameAccount.tagLine()).isEqualTo("KR1");
+        }
+
+        @Test
+        @DisplayName("게임 계정 미연동 유저 검색")
+        void search_user_without_game_account() {
+            // when
+            UserSearchListResponse result = userSearchService.search("일반유저", null, 10);
+
+            // then
+            assertThat(result.users()).hasSize(1);
+            UserSearchListResponse.GameAccountDto gameAccount = result.users().get(0).gameAccount();
+            assertThat(gameAccount.linked()).isFalse();
+            assertThat(gameAccount.gameName()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("페이징")
+    class PagingTest {
+
+        @BeforeEach
+        void setUpMultipleUsers() {
+            for (int i = 1; i <= 15; i++) {
+                userRepository.save(User.builder()
+                        .email("paging" + i + "@test.com")
+                        .password("password123")
+                        .nickname("페이징테스트" + i)
+                        .verificationCode("code" + i)
+                        .build());
+            }
+        }
+
+        @Test
+        @DisplayName("페이지 크기 제한 동작")
+        void search_with_page_size() {
+            // when
+            UserSearchListResponse result = userSearchService.search("페이징테스트", null, 5);
+
+            // then
+            assertThat(result.users()).hasSize(5);
+            assertThat(result.hasNext()).isTrue();
+            assertThat(result.nextCursor()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("커서 기반 페이징")
+        void search_with_cursor() {
+            // given
+            UserSearchListResponse firstPage = userSearchService.search("페이징테스트", null, 5);
+            Long cursor = firstPage.nextCursor();
+
+            // when
+            UserSearchListResponse secondPage = userSearchService.search("페이징테스트", cursor, 5);
+
+            // then
+            assertThat(secondPage.users()).hasSize(5);
+            assertThat(secondPage.users().get(0).userId()).isLessThan(cursor);
+        }
+
+        @Test
+        @DisplayName("마지막 페이지에서 hasNext는 false")
+        void search_last_page_has_no_next() {
+            // when
+            UserSearchListResponse result = userSearchService.search("페이징테스트", null, 50);
+
+            // then
+            assertThat(result.hasNext()).isFalse();
+            assertThat(result.nextCursor()).isNull();
+        }
+
+        @Test
+        @DisplayName("size가 null이면 기본값 10 적용")
+        void search_default_size() {
+            // when
+            UserSearchListResponse result = userSearchService.search("페이징테스트", null, null);
+
+            // then
+            assertThat(result.users()).hasSize(10);
+        }
+
+        @Test
+        @DisplayName("size가 50 초과시 최대 50으로 제한")
+        void search_max_size_limit() {
+            // when
+            UserSearchListResponse result = userSearchService.search("페이징테스트", null, 100);
+
+            // then
+            assertThat(result.users().size()).isLessThanOrEqualTo(50);
+        }
+    }
+}


### PR DESCRIPTION
<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #166 

## PR / 과제 설명 

프로젝트의 코드 품질과 안전성 향상을 위해 **각 도메인별 단위 테스트 및 통합테스트를 추가**했음.

---

### ✔️ 1. Party 도메인 

- `PartyServiceTest.java` → 파티 서비스 단위 테스트 
  - 파티 생성 / 조회 로직, 멤버 추가 / 제외 비즈니스 로직, 권한 검증 로직 

### ✔️ 2. Post 도메인 

- `PostControllerTest.java` → 모집글 API 통합 테스트 
  - 모집글 CRUD API, 모집글 상태 변경 
- `PostServiceTest.java` → 모집글 서비스 단위 테스트 
  - 모집글 CRUD 로직, 모집글 조회

### ✔️ 3. Chat 도메인 

- `ChatServiceTest.java` → 채팅 서비스 단위 테스트 (수정)
  - 채팅방 생성, 메시지 전송, 채팅방 목록 조회 
- `ChatUnreadCacheServiceTest.java` → 읽지 않음 캐시 테스트 
  - Redis 캐시 기반 읽지 않음 카운트 처리 

### ✔️ 4. Review 도메인

- `ReviewControllerTest.java` → 리뷰 API 통합 테스트 
  - 리뷰 작성, 리뷰 조회, 권한 검증 
- `ReviewServiceTest.java` → 리뷰 서비스 단위 테스트 
  - 리뷰 생성 로직, 중복 리뷰 방지 

### ✔️ 5. User 도메인
 
- `UserProfileServiceTest.java` → 유저 프로필 테스트 
  - 프로필 조회, 수정 
- `UserSignUpServiceTest.java` → 회원가입 테스트 
  - 회원가입 로직, 이메일 중복 검증 

### ✔️ 6. UserSearch 도메인
 
- `UserSearchServiceTest.java` → 유저 검색 테스트 

### ✔️ 7. GameAccount 도메인

- `GameAccountServiceTest.java` → 게임 계정 테스트 
  - 게임 계정 연동, 조회, 수정 

---

### 수정된 파일 

`PartyControllerTest.java` 패키지 경로 수정 → `(domain/party/controller/)`  

<img width="778" height="443" alt="image" src="https://github.com/user-attachments/assets/eaf2d9ef-8f55-4bce-84aa-0a1027ead313" />

> 전체 테스트 통과 했습니다

 
