### PR TITLE
[BE/refactor] V6__remove_wrong_unique_constraint.sql 수정

### DIFF
--- a/src/main/java/com/back/matchduo/domain/review/entity/Review.java
+++ b/src/main/java/com/back/matchduo/domain/review/entity/Review.java
@@ -9,6 +9,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
@@ -43,9 +45,9 @@ public class Review extends SoftDeletableEntity {
     @JoinColumn(name = "reviewee_id", nullable = false)
     private User reviewee;
 
-    // 요청 데이터가 삭제돼도 리뷰는 남아야 하므로 nullable = true
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_request_id", nullable = true)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private ReviewRequest reviewRequest;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/resources/db/migration/V6__remove_wrong_unique_constraint.sql
+++ b/src/main/resources/db/migration/V6__remove_wrong_unique_constraint.sql
@@ -1,2 +1,10 @@
 -- 유저당 하나만 생성 가능하게 막고 있는 잘못된 제약 조건 삭제
+-- 1. FK 삭제
+ALTER TABLE review_request DROP FOREIGN KEY FKi6fybm4ude799rrg8wj2i3abl;
+
+-- 2. 잘못된 단독 유니크 인덱스 삭제
 ALTER TABLE review_request DROP INDEX uk_review_request_post_user;
+
+-- 3. FK 재설정 (기존에 가졌던 제약조건 옵션을 반드시 확인 후 동일하게 부여)
+ALTER TABLE review_request ADD CONSTRAINT FKi6fybm4ude799rrg8wj2i3abl
+    FOREIGN KEY (request_user_id) REFERENCES user (id);


### PR DESCRIPTION
외래키 제약 조건 삭제 후 인덱스 삭제 후 다시 외래키 제약조건 생성

<!--
  PR 네이밍 규칙:
  [FE/feat] PR 내용
-->

## 관련 이슈

- close #번호

## PR / 과제 설명 
**1. V6__remove_wrong_unique_constraint.sql 수정**
- 외래키 제약 조건 삭제(FKi6fybm4ude799rrg8wj2i3abl)
- 인덱스 삭제(uk_review_request_post_user)
- 외래키 제약조건 재생성(FKi6fybm4ude799rrg8wj2i3abl)

**2. review엔티티 review_request 연관관계 수정**
-  @OnDelete(action = OnDeleteAction.SET_NULL) 추가
